### PR TITLE
US-3.1.7/listado-de-proyecto

### DIFF
--- a/src/main/java/com/a2/backend/controller/ProjectController.java
+++ b/src/main/java/com/a2/backend/controller/ProjectController.java
@@ -6,12 +6,10 @@ import com.a2.backend.service.ProjectService;
 import lombok.val;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequestMapping("/project")
@@ -28,5 +26,11 @@ public class ProjectController {
     public ResponseEntity<Project> postNewProject(@Valid @RequestBody ProjectCreateDTO projectCreateDTO) {
         val createdProject = projectService.createProject(projectCreateDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdProject);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Project>> getAllProjects() {
+        val projects = projectService.getAllProjects();
+        return ResponseEntity.status(HttpStatus.OK).body(projects);
     }
 }

--- a/src/main/java/com/a2/backend/service/ProjectService.java
+++ b/src/main/java/com/a2/backend/service/ProjectService.java
@@ -3,8 +3,12 @@ package com.a2.backend.service;
 import com.a2.backend.entity.Project;
 import com.a2.backend.model.ProjectCreateDTO;
 
+import java.util.List;
+
 public interface ProjectService{
 
     Project createProject(ProjectCreateDTO projectCreateDTO);
+
+    List<Project> getAllProjects();
 
 }

--- a/src/main/java/com/a2/backend/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/ProjectServiceImpl.java
@@ -8,6 +8,8 @@ import com.a2.backend.service.ProjectService;
 import lombok.val;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class ProjectServiceImpl implements ProjectService {
 
@@ -31,5 +33,10 @@ public class ProjectServiceImpl implements ProjectService {
         }
 
         throw new ProjectWithThatTitleExistsException(String.format("There is an existing project named %s", projectCreateDTO.getTitle()));
+    }
+
+    @Override
+    public List<Project> getAllProjects() {
+        return projectRepository.findAll();
     }
 }

--- a/src/test/java/com/a2/backend/controller/ProjectControllerTest.java
+++ b/src/test/java/com/a2/backend/controller/ProjectControllerTest.java
@@ -83,7 +83,7 @@ class ProjectControllerTest {
     @Test
     void Test004_ProjectControllerWhenReceiveCreateProjectDTOWithInvalidDescriptionAndTitleShouldReturnStatusBadRequest() {
         String title = "a";
-        String  description = "Short";
+        String description = "Short";
         String owner = "Owner´s name";
 
         ProjectCreateDTO projectToCreate = ProjectCreateDTO.builder()
@@ -96,6 +96,12 @@ class ProjectControllerTest {
 
         val getResponse = restTemplate.exchange(baseUrl, HttpMethod.POST, request, Project.class);
         assertEquals(HttpStatus.BAD_REQUEST, getResponse.getStatusCode());
+    }
+
+    @Test
+    void Test005_GettingAllProjectsShouldReturnHttpOkTest() {
+        val getResponse = restTemplate.exchange(baseUrl, HttpMethod.GET, null, Project[].class);
+        assertEquals(HttpStatus.OK, getResponse.getStatusCode());
     }
 
 }

--- a/src/test/java/com/a2/backend/service/impl/ProjectServiceImplTest.java
+++ b/src/test/java/com/a2/backend/service/impl/ProjectServiceImplTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 
 
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -85,4 +86,22 @@ class ProjectServiceImplTest {
         });
     }
 
+    @Test
+    void Test004_ProjectListWithNoSavedProjectsShouldBeEmpty() {
+        assertTrue(projectService.getAllProjects().isEmpty());
+    }
+
+    @Test
+    void Test005_ProjectListWithSavedProjectsShouldContainProjects() {
+        assertTrue(projectService.getAllProjects().isEmpty());
+
+        Project savedProject = projectService.createProject(projectToCreate);
+
+        List<Project> allProjects = projectService.getAllProjects();
+
+        assertEquals(1, allProjects.size());
+
+        Project singleProject = allProjects.get(0);
+        assertEquals(savedProject, singleProject);
+    }
 }


### PR DESCRIPTION
Como un usuario básico quiero poder listar los proyectos para poder visualizar todos los proyectos disponibles en la plataforma

UATs:

Cuando desde el front se piden los proyectos existentes al back cuando haya cualquier cantidad de proyectos se debe devolver una lista de proyectos que puede tener 0 o más proyectos con toda la información básica disponible y se deberán mostrar en el front end

Si el back llegara a fallar se debe mostrar un mensaje de error