### PR TITLE
Fixed assertions, Project.title changed to UUID and tweaked tests

### DIFF
--- a/src/main/java/com/a2/backend/controller/ProjectController.java
+++ b/src/main/java/com/a2/backend/controller/ProjectController.java
@@ -5,6 +5,7 @@ import com.a2.backend.model.ProjectCreateDTO;
 import com.a2.backend.model.ProjectUpdateDTO;
 import com.a2.backend.service.ProjectService;
 import java.util.List;
+import java.util.UUID;
 import javax.validation.Valid;
 import lombok.val;
 import org.springframework.http.HttpStatus;
@@ -35,20 +36,20 @@ public class ProjectController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<String> deleteProject(@PathVariable String id) {
+    public ResponseEntity<UUID> deleteProject(@PathVariable UUID id) {
         projectService.deleteProject(id);
         return ResponseEntity.status(HttpStatus.OK).body(id);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<Project> updateProject(
-            @RequestBody ProjectUpdateDTO projectUpdateDTO, @PathVariable String id) {
+            @Valid @RequestBody ProjectUpdateDTO projectUpdateDTO, @PathVariable UUID id) {
         val updatedProject = projectService.updateProject(projectUpdateDTO, id);
         return ResponseEntity.status(HttpStatus.OK).body(updatedProject);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Project> getProjectDetails(@PathVariable String id) {
+    public ResponseEntity<Project> getProjectDetails(@PathVariable UUID id) {
         val projectDetails = projectService.getProjectDetails(id);
         return ResponseEntity.status(HttpStatus.OK).body(projectDetails);
     }

--- a/src/main/java/com/a2/backend/entity/Project.java
+++ b/src/main/java/com/a2/backend/entity/Project.java
@@ -2,9 +2,9 @@ package com.a2.backend.entity;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.UUID;
 import javax.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
 
@@ -19,9 +19,8 @@ import org.hibernate.annotations.LazyCollectionOption;
 public class Project implements Serializable {
 
     @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid2")
-    private String id;
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
 
     private String title;
 

--- a/src/main/java/com/a2/backend/model/ProjectUpdateDTO.java
+++ b/src/main/java/com/a2/backend/model/ProjectUpdateDTO.java
@@ -1,5 +1,7 @@
 package com.a2.backend.model;
 
+import javax.validation.constraints.Size;
+
 import lombok.*;
 
 @Getter
@@ -10,8 +12,11 @@ import lombok.*;
 @AllArgsConstructor
 public class ProjectUpdateDTO {
 
+    @NonNull
+    @Size(min = 3, max = 100, message = "Title must be between 3 and 100 characters")
     private String title;
 
+    @Size(min = 10, max = 500, message = "Description must be between 10 and 500 characters")
     private String description;
 
     private String[] links;

--- a/src/main/java/com/a2/backend/repository/ProjectRepository.java
+++ b/src/main/java/com/a2/backend/repository/ProjectRepository.java
@@ -2,9 +2,11 @@ package com.a2.backend.repository;
 
 import com.a2.backend.entity.Project;
 import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProjectRepository extends JpaRepository<Project, String> {
+public interface ProjectRepository extends JpaRepository<Project, UUID> {
 
     Optional<Project> findByTitle(String title);
 }

--- a/src/main/java/com/a2/backend/service/ProjectService.java
+++ b/src/main/java/com/a2/backend/service/ProjectService.java
@@ -4,6 +4,7 @@ import com.a2.backend.entity.Project;
 import com.a2.backend.model.ProjectCreateDTO;
 import com.a2.backend.model.ProjectUpdateDTO;
 import java.util.List;
+import java.util.UUID;
 
 public interface ProjectService {
 
@@ -11,9 +12,9 @@ public interface ProjectService {
 
     List<Project> getAllProjects();
 
-    Project updateProject(ProjectUpdateDTO updateProject, String projectToBeUpdatedID);
+    Project updateProject(ProjectUpdateDTO updateProject, UUID projectToBeUpdatedID);
 
-    void deleteProject(String uuid);
+    void deleteProject(UUID uuid);
 
-    Project getProjectDetails(String id);
+    Project getProjectDetails(UUID id);
 }

--- a/src/main/java/com/a2/backend/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/ProjectServiceImpl.java
@@ -9,6 +9,8 @@ import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.service.ProjectService;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
+
 import lombok.val;
 import org.springframework.stereotype.Service;
 
@@ -48,7 +50,7 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
-    public Project updateProject(ProjectUpdateDTO projectUpdateDTO, String projectToBeUpdatedID) {
+    public Project updateProject(ProjectUpdateDTO projectUpdateDTO, UUID projectToBeUpdatedID) {
         val projectToModifyOptional = projectRepository.findById(projectToBeUpdatedID);
         if (projectToModifyOptional.isEmpty()) {
             throw new ProjectNotFoundException(
@@ -65,7 +67,7 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
-    public void deleteProject(String uuid) {
+    public void deleteProject(UUID uuid) {
         if (projectRepository.existsById(uuid)) {
             projectRepository.deleteById(uuid);
             return;
@@ -74,7 +76,7 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
-    public Project getProjectDetails(String projectID) {
+    public Project getProjectDetails(UUID projectID) {
         return projectRepository
                 .findById(projectID)
                 .orElseThrow(

--- a/src/test/java/com/a2/backend/service/impl/ProjectServiceImplTest.java
+++ b/src/test/java/com/a2/backend/service/impl/ProjectServiceImplTest.java
@@ -11,6 +11,8 @@ import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.service.ProjectService;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
+
 import lombok.val;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -156,7 +158,7 @@ class ProjectServiceImplTest {
     @Test
     void
             Test007_ProjectServiceWhenRecievesNonExistentProjectIDShouldThrowProjectNotFoundException() {
-        String nonexistentID = "id_001";
+        UUID nonexistentID = UUID.randomUUID();
         assertTrue(projectRepository.findById(nonexistentID).isEmpty());
 
         assertThrows(


### PR DESCRIPTION
- Project, línea 24: el uso de string para UUID. Ver el repo de ejemplo, esa es la forma correcta de usar UUID 
- assertEquals, no assertTrue o False, si están comparando valores. Si van a comprar y después chequear que eso es false o true cuando falla no te explica donde está la diferencia. En assertEquals si