### PR TITLE
Us 2.1.11/password recovery

### DIFF
--- a/src/main/java/com/a2/backend/controller/UserController.java
+++ b/src/main/java/com/a2/backend/controller/UserController.java
@@ -2,6 +2,7 @@ package com.a2.backend.controller;
 
 import com.a2.backend.constants.SecurityConstants;
 import com.a2.backend.entity.User;
+import com.a2.backend.model.PasswordRecoveryDTO;
 import com.a2.backend.model.UserCreateDTO;
 import com.a2.backend.model.UserUpdateDTO;
 import com.a2.backend.service.UserService;
@@ -36,8 +37,9 @@ public class UserController {
     }
 
     @PutMapping("/{email}")
-    public ResponseEntity<User> recoverPassword(@PathVariable String email, String newPassword) {
-        val userTobeUpdated = userService.recoverPassword(email, newPassword);
+    public ResponseEntity<User> recoverPassword(
+            @PathVariable String email, @RequestBody PasswordRecoveryDTO passwordRecoveryDTO) {
+        val userTobeUpdated = userService.recoverPassword(email, passwordRecoveryDTO);
         return ResponseEntity.status(HttpStatus.OK).body(userTobeUpdated);
     }
 

--- a/src/main/java/com/a2/backend/controller/UserController.java
+++ b/src/main/java/com/a2/backend/controller/UserController.java
@@ -3,6 +3,7 @@ package com.a2.backend.controller;
 import com.a2.backend.constants.SecurityConstants;
 import com.a2.backend.entity.User;
 import com.a2.backend.model.PasswordRecoveryDTO;
+import com.a2.backend.model.PasswordRecoveryInitDTO;
 import com.a2.backend.model.UserCreateDTO;
 import com.a2.backend.model.UserUpdateDTO;
 import com.a2.backend.service.UserService;
@@ -36,10 +37,17 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body(userConfirmed);
     }
 
-    @PutMapping("/{email}")
+    @GetMapping("/recover")
+    public ResponseEntity<?> passwordRecoveryInit(
+            @RequestBody PasswordRecoveryInitDTO passwordRecoveryInitDTO) {
+        userService.sendPasswordRecoveryMail(passwordRecoveryInitDTO);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PostMapping("/recover/request")
     public ResponseEntity<User> recoverPassword(
-            @PathVariable String email, @RequestBody PasswordRecoveryDTO passwordRecoveryDTO) {
-        val userTobeUpdated = userService.recoverPassword(email, passwordRecoveryDTO);
+            @RequestBody PasswordRecoveryDTO passwordRecoveryDTO) {
+        val userTobeUpdated = userService.recoverPassword(passwordRecoveryDTO);
         return ResponseEntity.status(HttpStatus.OK).body(userTobeUpdated);
     }
 

--- a/src/main/java/com/a2/backend/controller/UserController.java
+++ b/src/main/java/com/a2/backend/controller/UserController.java
@@ -35,6 +35,12 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body(userConfirmed);
     }
 
+    @PutMapping("/{email}")
+    public ResponseEntity<User> recoverPassword(@PathVariable String email, String newPassword) {
+        val userTobeUpdated = userService.recoverPassword(email, newPassword);
+        return ResponseEntity.status(HttpStatus.OK).body(userTobeUpdated);
+    }
+
     @Secured({SecurityConstants.USER_ROLE})
     @DeleteMapping
     public ResponseEntity<?> deleteUser() {

--- a/src/main/java/com/a2/backend/entity/User.java
+++ b/src/main/java/com/a2/backend/entity/User.java
@@ -31,7 +31,7 @@ public class User {
 
     @JsonIgnore String confirmationToken;
 
-    String passwordRecoveryToken;
+    @JsonIgnore String passwordRecoveryToken;
 
     @Builder.Default boolean isActive = false;
 }

--- a/src/main/java/com/a2/backend/entity/User.java
+++ b/src/main/java/com/a2/backend/entity/User.java
@@ -31,5 +31,7 @@ public class User {
 
     @JsonIgnore String confirmationToken;
 
+    String passwordRecoveryToken;
+
     @Builder.Default boolean isActive = false;
 }

--- a/src/main/java/com/a2/backend/exception/InvalidPasswordRecoveryException.java
+++ b/src/main/java/com/a2/backend/exception/InvalidPasswordRecoveryException.java
@@ -1,0 +1,7 @@
+package com.a2.backend.exception;
+
+public class InvalidPasswordRecoveryException extends RuntimeException {
+    public InvalidPasswordRecoveryException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/a2/backend/exception/PasswordRecoveryFailedException.java
+++ b/src/main/java/com/a2/backend/exception/PasswordRecoveryFailedException.java
@@ -1,0 +1,7 @@
+package com.a2.backend.exception;
+
+public class PasswordRecoveryFailedException extends RuntimeException {
+    public PasswordRecoveryFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
+++ b/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
@@ -60,6 +60,20 @@ public class DefaultExceptionHandler {
         return new ResponseEntity(exception.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(PasswordRecoveryFailedException.class)
+    public ResponseEntity<?> PasswordRecoveryFailedException(
+            PasswordRecoveryFailedException exception) {
+        logger.info(exception.getMessage());
+        return new ResponseEntity(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(InvalidPasswordRecoveryException.class)
+    public ResponseEntity<?> InvalidPasswordRecoveryException(
+            InvalidPasswordRecoveryException exception) {
+        logger.info(exception.getMessage());
+        return new ResponseEntity(exception.getMessage(), HttpStatus.OK);
+    }
+
     @ExceptionHandler(LanguageNotValidException.class)
     protected ResponseEntity<?> handleLanguageNotValid(LanguageNotValidException exception) {
         logger.info(exception.getMessage());

--- a/src/main/java/com/a2/backend/model/PasswordRecoveryDTO.java
+++ b/src/main/java/com/a2/backend/model/PasswordRecoveryDTO.java
@@ -1,0 +1,19 @@
+package com.a2.backend.model;
+
+import javax.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordRecoveryDTO {
+
+    @Size(min = 8, max = 32, message = "Password must be between 8 and 32 characters")
+    String newPassword;
+
+    @Size(min = 8, max = 32)
+    String passwordRecoveryToken;
+}

--- a/src/main/java/com/a2/backend/model/PasswordRecoveryDTO.java
+++ b/src/main/java/com/a2/backend/model/PasswordRecoveryDTO.java
@@ -18,6 +18,6 @@ public class PasswordRecoveryDTO {
     @Size(min = 8, max = 32, message = "Password must be between 8 and 32 characters")
     String newPassword;
 
-    @Size(min = 8, max = 32)
+    @Size(min = 32, max = 32)
     String passwordRecoveryToken;
 }

--- a/src/main/java/com/a2/backend/model/PasswordRecoveryDTO.java
+++ b/src/main/java/com/a2/backend/model/PasswordRecoveryDTO.java
@@ -1,5 +1,6 @@
 package com.a2.backend.model;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.Size;
 import lombok.*;
 
@@ -10,6 +11,9 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PasswordRecoveryDTO {
+
+    @Email(message = "Email must be valid")
+    String email;
 
     @Size(min = 8, max = 32, message = "Password must be between 8 and 32 characters")
     String newPassword;

--- a/src/main/java/com/a2/backend/model/PasswordRecoveryInitDTO.java
+++ b/src/main/java/com/a2/backend/model/PasswordRecoveryInitDTO.java
@@ -1,0 +1,16 @@
+package com.a2.backend.model;
+
+import javax.validation.constraints.Email;
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordRecoveryInitDTO {
+
+    @Email(message = "Email must be valid")
+    String email;
+}

--- a/src/main/java/com/a2/backend/service/MailService.java
+++ b/src/main/java/com/a2/backend/service/MailService.java
@@ -4,7 +4,7 @@ import com.a2.backend.entity.User;
 
 public interface MailService {
 
-    public void sendConfirmationMail(User user, String confirmationToken);
+    public void sendConfirmationMail(User user);
 
-    public void sendForgotPasswordMail(String mail);
+    public void sendForgotPasswordMail(User user);
 }

--- a/src/main/java/com/a2/backend/service/UserService.java
+++ b/src/main/java/com/a2/backend/service/UserService.java
@@ -1,6 +1,7 @@
 package com.a2.backend.service;
 
 import com.a2.backend.entity.User;
+import com.a2.backend.model.PasswordRecoveryDTO;
 import com.a2.backend.model.UserCreateDTO;
 import com.a2.backend.model.UserUpdateDTO;
 import java.util.UUID;
@@ -11,7 +12,7 @@ public interface UserService {
 
     User confirmUser(String token, UUID userid);
 
-    User recoverPassword(String email, String newPassword);
+    User recoverPassword(String email, PasswordRecoveryDTO passwordRecoveryDTO);
 
     void deleteUser();
 

--- a/src/main/java/com/a2/backend/service/UserService.java
+++ b/src/main/java/com/a2/backend/service/UserService.java
@@ -2,6 +2,7 @@ package com.a2.backend.service;
 
 import com.a2.backend.entity.User;
 import com.a2.backend.model.PasswordRecoveryDTO;
+import com.a2.backend.model.PasswordRecoveryInitDTO;
 import com.a2.backend.model.UserCreateDTO;
 import com.a2.backend.model.UserUpdateDTO;
 import java.util.UUID;
@@ -12,9 +13,11 @@ public interface UserService {
 
     User confirmUser(String token, UUID userid);
 
-    User recoverPassword(String email, PasswordRecoveryDTO passwordRecoveryDTO);
+    User recoverPassword(PasswordRecoveryDTO passwordRecoveryDTO);
 
     void deleteUser();
 
     User updateUser(UserUpdateDTO userUpdateDTO);
+
+    void sendPasswordRecoveryMail(PasswordRecoveryInitDTO passwordRecoveryInitDTO);
 }

--- a/src/main/java/com/a2/backend/service/UserService.java
+++ b/src/main/java/com/a2/backend/service/UserService.java
@@ -11,6 +11,8 @@ public interface UserService {
 
     User confirmUser(String token, UUID userid);
 
+    User recoverPassword(String email, String newPassword);
+
     void deleteUser();
 
     User updateUser(UserUpdateDTO userUpdateDTO);

--- a/src/main/java/com/a2/backend/service/impl/MailServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/MailServiceImpl.java
@@ -20,17 +20,24 @@ public class MailServiceImpl implements MailService {
     }
 
     @Override
-    public void sendConfirmationMail(User user, String confirmationToken) {
+    public void sendConfirmationMail(User user) {
         this.sendEmail(
                 user.getEmail(),
                 "Account confirmation",
                 "Hello in order to confirm your account press this link: "
                         + "http://localhost:3000/user/confirm?token="
-                        + confirmationToken);
+                        + user.getConfirmationToken());
     }
 
     @Override
-    public void sendForgotPasswordMail(String mail) {}
+    public void sendForgotPasswordMail(User user) {
+        this.sendEmail(
+                user.getEmail(),
+                "Password Recovery",
+                "Hello in order to confirm your account press this link: "
+                        + "http://localhost:3000/user/recover/forgot-password?token="
+                        + user.getPasswordRecoveryToken());
+    }
 
     private void sendEmail(String mailTO, String subject, String content) {
         SimpleMailMessage message = new SimpleMailMessage();

--- a/src/main/java/com/a2/backend/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/UserServiceImpl.java
@@ -106,4 +106,17 @@ public class UserServiceImpl implements UserService {
         user.setActive(true);
         return userRepository.save(user);
     }
+
+    @Override
+    public User recoverPassword(String email, String newPassword) {
+        val userOptional = userRepository.findByEmail(email);
+        if (userOptional.isEmpty()) {
+            return null;
+        }
+        val userToUpdatePassword = userOptional.get();
+
+        userToUpdatePassword.setPassword(newPassword);
+
+        return userRepository.save(userToUpdatePassword);
+    }
 }

--- a/src/main/java/com/a2/backend/utils/RandomStringUtils.java
+++ b/src/main/java/com/a2/backend/utils/RandomStringUtils.java
@@ -1,0 +1,31 @@
+package com.a2.backend.utils;
+
+// Java program generate a random AlphaNumeric String
+// using Math.random() method
+
+public class RandomStringUtils {
+
+    private RandomStringUtils() {}
+    // function to generate a random string of length n
+    public static String getAlphaNumericString(int n) {
+
+        // chose a Character random from this String
+        String AlphaNumericString =
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "0123456789" + "abcdefghijklmnopqrstuvxyz";
+
+        // create StringBuffer size of AlphaNumericString
+        StringBuilder sb = new StringBuilder(n);
+
+        for (int i = 0; i < n; i++) {
+
+            // generate a random number between
+            // 0 to AlphaNumericString variable length
+            int index = (int) (AlphaNumericString.length() * Math.random());
+
+            // add Character one by one in end of sb
+            sb.append(AlphaNumericString.charAt(index));
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/test/java/com/a2/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/a2/backend/controller/UserControllerTest.java
@@ -7,6 +7,7 @@ import com.a2.backend.entity.User;
 import com.a2.backend.model.PasswordRecoveryDTO;
 import com.a2.backend.model.UserCreateDTO;
 import com.a2.backend.model.UserUpdateDTO;
+import com.a2.backend.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.val;
 import org.junit.jupiter.api.Test;
@@ -34,15 +35,19 @@ class UserControllerTest {
 
     @Autowired MockMvc mvc;
     @Autowired ObjectMapper objectMapper;
+    @Autowired UserRepository userRepository;
 
     private final String baseUrl = "/user";
     private final String confirmationUrl = "/confirm";
+    private final String recoverUrl = "recover";
+    private final String requestUrl = "request";
 
     private final String nickname = "nickname";
     private final String email = "some@gmail.com";
     private final String biography = "bio";
     private final String password = "password";
     private final String confirmationToken = "token001";
+    private final String recoveryToken = "RecoveryToken";
 
     UserCreateDTO userCreateDTO =
             UserCreateDTO.builder()
@@ -51,6 +56,12 @@ class UserControllerTest {
                     .biography(biography)
                     .password(password)
                     .confirmationToken(confirmationToken)
+                    .build();
+    PasswordRecoveryDTO passwordRecoveryDTO =
+            PasswordRecoveryDTO.builder()
+                    .email(email)
+                    .passwordRecoveryToken(recoveryToken)
+                    .newPassword("NewPassword001")
                     .build();
 
     @Test
@@ -403,58 +414,48 @@ class UserControllerTest {
     }
 
     @Test
-    void GivenAvalidUserWhenWantToRecoverPasswordThenReturnStatusOk() {
-        UserCreateDTO userCreateDTO =
-                UserCreateDTO.builder()
-                        .nickname(nickname)
-                        .email(email)
-                        .biography(biography)
-                        .password(password)
-                        .confirmationToken(confirmationToken)
-                        .build();
-        PasswordRecoveryDTO passwordRecoveryDTO =
-                PasswordRecoveryDTO.builder()
-                        .passwordRecoveryToken("")
-                        .newPassword("NewPassword001")
-                        .build();
+    void GivenAValidUserWhenWantToRecoverPasswordThenReturnStatusOk() {
         String validConfirmationToken = "token001";
+        HttpEntity<UserCreateDTO> userRequest = new HttpEntity<>(userCreateDTO);
+        val getResponse = restTemplate.exchange(baseUrl, HttpMethod.POST, userRequest, User.class);
+        assertEquals(HttpStatus.CREATED, getResponse.getStatusCode());
+        // agarras response id, llamas al user service
+        val recoverPasswordToken =
+                userRepository
+                        .findById(getResponse.getBody().getId())
+                        .get()
+                        .getPasswordRecoveryToken();
 
-        HttpEntity<UserCreateDTO> request = new HttpEntity<>(userCreateDTO);
-        HttpEntity<PasswordRecoveryDTO> requestPasswordRecovery =
-                new HttpEntity<>(passwordRecoveryDTO);
-
-        val postResponse = restTemplate.exchange(baseUrl, HttpMethod.POST, request, User.class);
-        assertEquals(HttpStatus.CREATED, postResponse.getStatusCode());
-
-        User userToBeUpdated = postResponse.getBody();
-
-        val getResponse =
+        User userToActivate = getResponse.getBody();
+        val getActivateResponse =
                 restTemplate.exchange(
                         String.format(
                                 "%s/%s/%s/%s",
                                 baseUrl,
                                 confirmationUrl,
-                                userToBeUpdated.getId(),
+                                userToActivate.getId(),
                                 validConfirmationToken),
                         HttpMethod.GET,
                         null,
                         User.class);
-        assertEquals(HttpStatus.OK, getResponse.getStatusCode());
-        passwordRecoveryDTO.setPasswordRecoveryToken(userToBeUpdated.getPasswordRecoveryToken());
+        assertEquals(HttpStatus.OK, getActivateResponse.getStatusCode());
+        passwordRecoveryDTO.setPasswordRecoveryToken(recoverPasswordToken);
+        HttpEntity<PasswordRecoveryDTO> passwordRecoveryRequest =
+                new HttpEntity<>(passwordRecoveryDTO);
 
-        User activatedUserToBeUpdated = getResponse.getBody();
-        System.out.println(userToBeUpdated.getPassword());
-
-        val putResponse =
+        val postResponse =
                 restTemplate.exchange(
-                        String.format("%s/%s", baseUrl, activatedUserToBeUpdated.getEmail()),
-                        HttpMethod.PUT,
-                        requestPasswordRecovery,
+                        String.format("%s/%s/%s", baseUrl, recoverUrl, requestUrl),
+                        HttpMethod.POST,
+                        passwordRecoveryRequest,
                         User.class);
-        assertEquals(HttpStatus.OK, putResponse.getStatusCode());
+        assertEquals(HttpStatus.OK, postResponse.getStatusCode());
 
-        User updatedUser = putResponse.getBody();
+        getActivateResponse
+                .getBody()
+                .setPasswordRecoveryToken(passwordRecoveryDTO.getPasswordRecoveryToken());
+        val activatedUser = getActivateResponse.getBody();
 
-        System.out.println(updatedUser.getPassword());
+        assertNotEquals(activatedUser.getPassword(), postResponse.getBody().getPassword());
     }
 }

--- a/src/test/java/com/a2/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/a2/backend/controller/UserControllerTest.java
@@ -251,6 +251,8 @@ class UserControllerTest {
         val activatedUser = getResponse.getBody();
         assertNotNull(activatedUser);
         assertTrue(activatedUser.isActive());
+
+        System.out.println("This is a password: " + userToActivate.getPassword());
     }
 
     @Test

--- a/src/test/java/com/a2/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/a2/backend/controller/UserControllerTest.java
@@ -263,8 +263,6 @@ class UserControllerTest {
         val activatedUser = getResponse.getBody();
         assertNotNull(activatedUser);
         assertTrue(activatedUser.isActive());
-
-        System.out.println("This is a password: " + userToActivate.getPassword());
     }
 
     @Test

--- a/src/test/java/com/a2/backend/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/a2/backend/service/impl/UserServiceImplTest.java
@@ -313,7 +313,7 @@ class UserServiceImplTest {
     }
 
     @Test
-    void Test013_GivenAnInvalidPasswordLengthWhenWantToRecoverPasswordThenReturnNull() {
+    void Test013_GivenAnInvalidPasswordLengthWhenWantToRecoverPasswordThenThrowPasswordRecoveryException() {
         User user = userService.createUser(userCreateDTO);
         User userToBeUpdated = userService.confirmUser(confirmationToken, user.getId());
         passwordRecoveryDTO.setPasswordRecoveryToken(user.getPasswordRecoveryToken());

--- a/src/test/java/com/a2/backend/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/a2/backend/service/impl/UserServiceImplTest.java
@@ -7,10 +7,7 @@ import com.a2.backend.exception.TokenConfirmationFailedException;
 import com.a2.backend.exception.UserNotFoundException;
 import com.a2.backend.exception.UserWithThatEmailExistsException;
 import com.a2.backend.exception.UserWithThatNicknameExistsException;
-import com.a2.backend.model.PasswordRecoveryDTO;
-import com.a2.backend.model.ProjectCreateDTO;
-import com.a2.backend.model.UserCreateDTO;
-import com.a2.backend.model.UserUpdateDTO;
+import com.a2.backend.model.*;
 import com.a2.backend.service.ProjectService;
 import com.a2.backend.service.UserService;
 import com.a2.backend.utils.RandomStringUtils;
@@ -47,8 +44,11 @@ class UserServiceImplTest {
             PasswordRecoveryDTO.builder()
                     .passwordRecoveryToken(passwordRecoveryToken)
                     .newPassword(newPassword)
+                    .email(email)
                     .build();
 
+    PasswordRecoveryInitDTO passwordRecoveryInitDTO =
+            PasswordRecoveryInitDTO.builder().email(email).build();
     UserCreateDTO userCreateDTO =
             UserCreateDTO.builder()
                     .nickname(nickname)
@@ -280,8 +280,7 @@ class UserServiceImplTest {
 
         User userToBeUpdated = userService.confirmUser("token001", user.getId());
 
-        User passwordUpdatedUser =
-                userService.recoverPassword(userToBeUpdated.getEmail(), passwordRecoveryDTO);
+        User passwordUpdatedUser = userService.recoverPassword(passwordRecoveryDTO);
 
         assertNotEquals(userToBeUpdated.getPassword(), passwordUpdatedUser.getPassword());
 
@@ -293,15 +292,15 @@ class UserServiceImplTest {
         User user = userService.createUser(userCreateDTO);
         passwordRecoveryDTO.setPasswordRecoveryToken(user.getPasswordRecoveryToken());
 
-        User passwordUpdatedUser =
-                userService.recoverPassword(user.getEmail(), passwordRecoveryDTO);
+        User passwordUpdatedUser = userService.recoverPassword(passwordRecoveryDTO);
 
         assertEquals(null, passwordUpdatedUser);
     }
 
     @Test
     void Test011_GivenAnInvalidEmailWhenWantToRecoverPasswordThenReturnNull() {
-        User passwordUpdatedUser = userService.recoverPassword("uselessMail", passwordRecoveryDTO);
+        passwordRecoveryDTO.setEmail("adihajkd");
+        User passwordUpdatedUser = userService.recoverPassword(passwordRecoveryDTO);
         assertEquals(null, passwordUpdatedUser);
     }
 
@@ -312,18 +311,17 @@ class UserServiceImplTest {
         User activatedUser = userService.confirmUser(confirmationToken, user.getId());
         assertThrows(
                 TokenConfirmationFailedException.class,
-                () -> userService.recoverPassword(activatedUser.getEmail(), passwordRecoveryDTO));
+                () -> userService.recoverPassword(passwordRecoveryDTO));
     }
 
     @Test
-    void Test013_GivenAninvalidPasswordLengthWhenWantToRecoverPasswordThenReturnNull() {
+    void Test013_GivenAnInvalidPasswordLengthWhenWantToRecoverPasswordThenReturnNull() {
         User user = userService.createUser(userCreateDTO);
         passwordRecoveryDTO.setPasswordRecoveryToken(user.getPasswordRecoveryToken());
         passwordRecoveryDTO.setNewPassword("test001");
         User userToBeUpdated = userService.confirmUser("token001", user.getId());
-
-        User passwordUpdatedUser =
-                userService.recoverPassword(userToBeUpdated.getEmail(), passwordRecoveryDTO);
+        passwordRecoveryDTO.setEmail(userToBeUpdated.getEmail());
+        User passwordUpdatedUser = userService.recoverPassword(passwordRecoveryDTO);
 
         assertEquals(null, passwordUpdatedUser);
     }

--- a/src/test/java/com/a2/backend/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/a2/backend/service/impl/UserServiceImplTest.java
@@ -3,14 +3,10 @@ package com.a2.backend.service.impl;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.a2.backend.entity.User;
-import com.a2.backend.exception.TokenConfirmationFailedException;
-import com.a2.backend.exception.UserNotFoundException;
-import com.a2.backend.exception.UserWithThatEmailExistsException;
-import com.a2.backend.exception.UserWithThatNicknameExistsException;
+import com.a2.backend.exception.*;
 import com.a2.backend.model.*;
 import com.a2.backend.service.ProjectService;
 import com.a2.backend.service.UserService;
-import com.a2.backend.utils.RandomStringUtils;
 import java.util.Arrays;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
@@ -176,7 +172,6 @@ class UserServiceImplTest {
         User activatedUser = userService.confirmUser(confirmationToken1, user.getId());
 
         assertTrue(activatedUser.isActive());
-        System.out.println("this is the password: " + activatedUser.getPassword());
     }
 
     @Test
@@ -288,20 +283,23 @@ class UserServiceImplTest {
     }
 
     @Test
-    void Test010_GivenAnInactiveUserWhenWantToRecoverPassWordThenReturnNull() {
+    void
+            Test010_GivenAnInactiveUserWhenWantToRecoverPassWordThenThrowInvalidPasswordRecoveryException() {
         User user = userService.createUser(userCreateDTO);
         passwordRecoveryDTO.setPasswordRecoveryToken(user.getPasswordRecoveryToken());
 
-        User passwordUpdatedUser = userService.recoverPassword(passwordRecoveryDTO);
-
-        assertEquals(null, passwordUpdatedUser);
+        assertThrows(
+                InvalidPasswordRecoveryException.class,
+                () -> userService.recoverPassword(passwordRecoveryDTO));
     }
 
     @Test
-    void Test011_GivenAnInvalidEmailWhenWantToRecoverPasswordThenReturnNull() {
+    void
+            Test011_GivenAnInvalidEmailWhenWantToRecoverPasswordThenThrowInvalidPasswordRecoveryException() {
         passwordRecoveryDTO.setEmail("adihajkd");
-        User passwordUpdatedUser = userService.recoverPassword(passwordRecoveryDTO);
-        assertEquals(null, passwordUpdatedUser);
+        assertThrows(
+                InvalidPasswordRecoveryException.class,
+                () -> userService.recoverPassword(passwordRecoveryDTO));
     }
 
     @Test
@@ -317,18 +315,13 @@ class UserServiceImplTest {
     @Test
     void Test013_GivenAnInvalidPasswordLengthWhenWantToRecoverPasswordThenReturnNull() {
         User user = userService.createUser(userCreateDTO);
+        User userToBeUpdated = userService.confirmUser(confirmationToken, user.getId());
         passwordRecoveryDTO.setPasswordRecoveryToken(user.getPasswordRecoveryToken());
         passwordRecoveryDTO.setNewPassword("test001");
-        User userToBeUpdated = userService.confirmUser("token001", user.getId());
         passwordRecoveryDTO.setEmail(userToBeUpdated.getEmail());
-        User passwordUpdatedUser = userService.recoverPassword(passwordRecoveryDTO);
 
-        assertEquals(null, passwordUpdatedUser);
-    }
-
-    @Test
-    void Test014_GivenAnIntWhenWantARandomStringThenCreatesTheRandomString() {
-        String randomStringTest = RandomStringUtils.getAlphaNumericString(10);
-        System.out.println(randomStringTest);
+        assertThrows(
+                PasswordRecoveryFailedException.class,
+                () -> userService.recoverPassword(passwordRecoveryDTO));
     }
 }

--- a/src/test/java/com/a2/backend/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/a2/backend/service/impl/UserServiceImplTest.java
@@ -162,6 +162,7 @@ class UserServiceImplTest {
         User activatedUser = userService.confirmUser(confirmationToken1, user.getId());
 
         assertTrue(activatedUser.isActive());
+        System.out.println("this is the password: " + activatedUser.getPassword());
     }
 
     @Test
@@ -255,5 +256,16 @@ class UserServiceImplTest {
         assertThrows(
                 UserWithThatNicknameExistsException.class,
                 () -> userService.updateUser(userUpdateDTO));
+    }
+
+    @Test
+    void
+            Test009_GivenaValidEmailandValidNewPasswordWhenWantToRecoverPasswordThenChangeTheOldPasswordForNewOne() {
+        User user = userService.createUser(userCreateDTO);
+        String newPassword = "newpassword001";
+
+        User passwordUpdatedUser = userService.recoverPassword(user.getEmail(), newPassword);
+
+        assertEquals(newPassword, passwordUpdatedUser.getPassword());
     }
 }


### PR DESCRIPTION
Como usuario registrado quiero poder pedir modificar mi contraseña con un mecanismo seguro para poder recuperar el acceso a mi cuenta 

UATs:
- Se debe solicitar al usuario su email, en caso de que el email no exista igualmente el formulario se completa de manera normal.
- Si el email no está registrado el backend ignora el pedido de recuperación y no envía nada.
- Una vez completado el formulario se muestra el mensaje pidiendo al usuario que verifique su email.
- En el formulario de recupero de contraseña las restricciones son las mismas que en el alta de usuarios (requerido, mínimo 8, máximo 32, se debe verificar en el frontend pidiendo que se repita y las dos contraseñas provistas deben coincidir)
