### PR TITLE
Us/tags de lenguajes

### DIFF
--- a/src/main/java/com/a2/backend/DemoRunner.java
+++ b/src/main/java/com/a2/backend/DemoRunner.java
@@ -1,6 +1,7 @@
 package com.a2.backend;
 
 import com.a2.backend.annotation.Generated;
+import com.a2.backend.entity.Language;
 import com.a2.backend.entity.Project;
 import com.a2.backend.entity.Tag;
 import com.a2.backend.entity.User;
@@ -110,6 +111,10 @@ public class DemoRunner implements CommandLineRunner {
                                         Tag.builder().name("GNU").build(),
                                         Tag.builder().name("Linux").build()))
                         .owner(userRepository.findByNickname("Peltevis").get())
+                        .languages(
+                                listOf(
+                                        Language.builder().name("C").build(),
+                                        Language.builder().name("C++").build()))
                         .build();
         Project tensorFlow =
                 Project.builder()
@@ -124,6 +129,10 @@ public class DemoRunner implements CommandLineRunner {
                                         Tag.builder().name("CUDA").build(),
                                         Tag.builder().name("C").build()))
                         .owner(userRepository.findByNickname("ropa1998").get())
+                        .languages(
+                                listOf(
+                                        Language.builder().name("Python").build(),
+                                        Language.builder().name("ML").build()))
                         .build();
         Project node =
                 Project.builder()
@@ -137,6 +146,11 @@ public class DemoRunner implements CommandLineRunner {
                                         Tag.builder().name("V8").build(),
                                         Tag.builder().name("Node").build()))
                         .owner(userRepository.findByNickname("FabriDS23").get())
+                        .languages(
+                                listOf(
+                                        Language.builder().name("JavaScript").build(),
+                                        Language.builder().name("Node").build(),
+                                        Language.builder().name("V8").build()))
                         .build();
         projectRepository.save(linux);
         projectRepository.save(tensorFlow);

--- a/src/main/java/com/a2/backend/DemoRunner.java
+++ b/src/main/java/com/a2/backend/DemoRunner.java
@@ -7,6 +7,9 @@ import com.a2.backend.entity.Tag;
 import com.a2.backend.entity.User;
 import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.repository.UserRepository;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,25 +18,17 @@ import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Component("DemoRunner")
 @Transactional
 @Generated
 public class DemoRunner implements CommandLineRunner {
     private static final Logger logger = LoggerFactory.getLogger(DemoRunner.class);
 
-    @Autowired
-    private Environment env;
-    @Autowired
-    private ProjectRepository projectRepository;
-    @Autowired
-    private UserRepository userRepository;
+    @Autowired private Environment env;
+    @Autowired private ProjectRepository projectRepository;
+    @Autowired private UserRepository userRepository;
 
-    public DemoRunner() {
-    }
+    public DemoRunner() {}
 
     @Override
     public void run(String... args) {

--- a/src/main/java/com/a2/backend/controller/ProjectController.java
+++ b/src/main/java/com/a2/backend/controller/ProjectController.java
@@ -62,4 +62,10 @@ public class ProjectController {
         val projectDetails = projectService.getProjectDetails(id);
         return ResponseEntity.status(HttpStatus.OK).body(projectDetails);
     }
+
+    @GetMapping("/languages")
+    public ResponseEntity<List<String>> getValidLanguages() {
+        val validLanguages = projectService.getValidLanguageNames();
+        return ResponseEntity.status(HttpStatus.OK).body(validLanguages);
+    }
 }

--- a/src/main/java/com/a2/backend/controller/UserController.java
+++ b/src/main/java/com/a2/backend/controller/UserController.java
@@ -5,14 +5,13 @@ import com.a2.backend.entity.User;
 import com.a2.backend.model.UserCreateDTO;
 import com.a2.backend.model.UserUpdateDTO;
 import com.a2.backend.service.UserService;
+import java.util.UUID;
+import javax.validation.Valid;
 import lombok.val;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/user")

--- a/src/main/java/com/a2/backend/entity/Language.java
+++ b/src/main/java/com/a2/backend/entity/Language.java
@@ -1,0 +1,25 @@
+package com.a2.backend.entity;
+
+import java.util.UUID;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class Language {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private String name;
+}

--- a/src/main/java/com/a2/backend/entity/Project.java
+++ b/src/main/java/com/a2/backend/entity/Project.java
@@ -34,6 +34,10 @@ public class Project implements Serializable {
     @LazyCollection(LazyCollectionOption.FALSE)
     private List<Tag> tags;
 
+    @ManyToMany(cascade = CascadeType.ALL)
+    @LazyCollection(LazyCollectionOption.FALSE)
+    private List<Language> languages;
+
     @ManyToOne(cascade = {CascadeType.MERGE})
     private User owner;
 }

--- a/src/main/java/com/a2/backend/exception/LanguageNotValidException.java
+++ b/src/main/java/com/a2/backend/exception/LanguageNotValidException.java
@@ -1,0 +1,7 @@
+package com.a2.backend.exception;
+
+public class LanguageNotValidException extends RuntimeException {
+    public LanguageNotValidException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
+++ b/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
@@ -59,4 +59,10 @@ public class DefaultExceptionHandler {
         logger.info(exception.getMessage());
         return new ResponseEntity(exception.getMessage(), HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(LanguageNotValidException.class)
+    protected ResponseEntity<?> handleLanguageNotValid(LanguageNotValidException exception) {
+        logger.info(exception.getMessage());
+        return new ResponseEntity(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/a2/backend/model/ProjectCreateDTO.java
+++ b/src/main/java/com/a2/backend/model/ProjectCreateDTO.java
@@ -20,11 +20,14 @@ public class ProjectCreateDTO {
     @Size(min = 10, max = 500, message = "Description must be between 10 and 500 characters")
     private String description;
 
-    @Size(min = 1, max = 5)
+    @Size(min = 1, max = 5, message = "Number of links must be between 1 and 5")
     private List<String> links;
 
-    @Size(min = 1, max = 5)
+    @Size(min = 1, max = 5, message = "Number of tags must be between 1 and 5")
     private List<@Size(min = 1, max = 24) String> tags;
+
+    @Size(min = 1, max = 3, message = "Number of languages must be between 1 and 3")
+    private List<String> languages;
 
     @NonNull private User owner;
 }

--- a/src/main/java/com/a2/backend/model/ProjectUpdateDTO.java
+++ b/src/main/java/com/a2/backend/model/ProjectUpdateDTO.java
@@ -19,9 +19,12 @@ public class ProjectUpdateDTO {
     @Size(min = 10, max = 500, message = "Description must be between 10 and 500 characters")
     private String description;
 
-    @Size(min = 1, max = 5)
+    @Size(min = 1, max = 5, message = "Number of links must be between 1 and 5")
     private List<String> links;
 
-    @Size(min = 1, max = 5)
+    @Size(min = 1, max = 5, message = "Number of tags must be between 1 and 5")
     private List<@Size(min = 1, max = 24) String> tags;
+
+    @Size(min = 1, max = 3, message = "Number of languages must be between 1 and 3")
+    private List<String> languages;
 }

--- a/src/main/java/com/a2/backend/model/UserUpdateDTO.java
+++ b/src/main/java/com/a2/backend/model/UserUpdateDTO.java
@@ -1,9 +1,8 @@
 package com.a2.backend.model;
 
+import javax.validation.constraints.Size;
 import lombok.*;
 import org.springframework.lang.Nullable;
-
-import javax.validation.constraints.Size;
 
 @Getter
 @Setter

--- a/src/main/java/com/a2/backend/repository/LanguageRepository.java
+++ b/src/main/java/com/a2/backend/repository/LanguageRepository.java
@@ -1,0 +1,11 @@
+package com.a2.backend.repository;
+
+import com.a2.backend.entity.Language;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LanguageRepository extends JpaRepository<Language, UUID> {
+
+    Optional<Language> findByName(String name);
+}

--- a/src/main/java/com/a2/backend/repository/ProjectRepository.java
+++ b/src/main/java/com/a2/backend/repository/ProjectRepository.java
@@ -20,4 +20,7 @@ public interface ProjectRepository extends JpaRepository<Project, UUID> {
     List<Project> findProjectsByTagName(String tagName);
 
     Page<Project> findByTitleContainingIgnoreCase(String pattern, Pageable pageable);
+
+    @Query("SELECT DISTINCT p FROM Project p JOIN p.languages l  WHERE l.name LIKE %?1%")
+    List<Project> findProjectsByLanguageName(String languageName);
 }

--- a/src/main/java/com/a2/backend/service/LanguageService.java
+++ b/src/main/java/com/a2/backend/service/LanguageService.java
@@ -1,0 +1,24 @@
+package com.a2.backend.service;
+
+import com.a2.backend.entity.Language;
+import java.util.List;
+import java.util.Optional;
+
+public interface LanguageService {
+
+    List<Language> findOrCreateLanguage(List<String> languagesToAdd);
+
+    Language createLanguage(String languageName);
+
+    Optional<Language> findLanguageByName(String languageName);
+
+    List<Language> findLanguagesByNames(List<String> languagesToFind);
+
+    List<Language> getRemovedLanguages(List<String> updated, List<Language> current);
+
+    void deleteUnusedLanguages(List<Language> removedLanguages);
+
+    List<Language> getAllLanguages();
+
+    List<String> getValidLanguages();
+}

--- a/src/main/java/com/a2/backend/service/ProjectService.java
+++ b/src/main/java/com/a2/backend/service/ProjectService.java
@@ -22,4 +22,6 @@ public interface ProjectService {
     void deleteProjectsFromUser(User owner);
 
     List<Project> getProjectsByTitleSearch(String pattern, int pageNo);
+
+    List<String> getValidLanguageNames();
 }

--- a/src/main/java/com/a2/backend/service/UserService.java
+++ b/src/main/java/com/a2/backend/service/UserService.java
@@ -3,7 +3,6 @@ package com.a2.backend.service;
 import com.a2.backend.entity.User;
 import com.a2.backend.model.UserCreateDTO;
 import com.a2.backend.model.UserUpdateDTO;
-
 import java.util.UUID;
 
 public interface UserService {

--- a/src/main/java/com/a2/backend/service/impl/LanguageServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/LanguageServiceImpl.java
@@ -1,0 +1,106 @@
+package com.a2.backend.service.impl;
+
+import com.a2.backend.entity.Language;
+import com.a2.backend.exception.LanguageNotValidException;
+import com.a2.backend.repository.LanguageRepository;
+import com.a2.backend.repository.ProjectRepository;
+import com.a2.backend.service.LanguageService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LanguageServiceImpl implements LanguageService {
+
+    private final LanguageRepository languageRepository;
+
+    private final ProjectRepository projectRepository;
+
+    private final String validLanguageNames =
+            "Java, C, C++, C#, Python, Visual Basic .NET, PHP, JavaScript, TypeScript, Delphi/Object Pascal, Swift, Perl, Ruby, Assembly language, R, Visual Basic, Objective-C, Go, MATLAB, PL/SQL, Scratch, SAS, D, Dart, ABAP, COBOL, Ada, Fortran, Transact-SQL, Lua, Scala, Logo, F#, Lisp, LabVIEW, Prolog, Haskell, Scheme, Groovy, RPG (OS/400), Apex, Erlang, MQL4, Rust, Bash, Ladder Logic, Q, Julia, Alice, VHDL, Awk, (Visual) FoxPro, ABC, ActionScript, APL, AutoLISP, bc, BlitzMax, Bourne shell, C shell, CFML, cg, CL (OS/400), Clipper, Clojure, Common Lisp, Crystal, Eiffel, Elixir, Elm, Emacs Lisp, Forth, Hack, Icon, IDL, Inform, Io, J, Korn shell, Kotlin, Maple, ML, NATURAL, NXT-G, OCaml, OpenCL, OpenEdge ABL, Oz, PL/I, PowerShell, REXX, Ring, S, Smalltalk, SPARK, SPSS, Standard ML, Stata, Tcl, VBScript, Verilog";
+
+    private final List<String> validLanguageList =
+            new ArrayList<>(Arrays.asList(validLanguageNames.split(", ")));
+
+    public LanguageServiceImpl(
+            LanguageRepository languageRepository, ProjectRepository projectRepository) {
+        this.languageRepository = languageRepository;
+        this.projectRepository = projectRepository;
+    }
+
+    @Override
+    public List<Language> findOrCreateLanguage(List<String> languagesToAdd) {
+        List<Language> languageList = new ArrayList<>();
+
+        for (String languageName : languagesToAdd) {
+            Optional<Language> optionalLanguage = findLanguageByName(languageName);
+
+            if (optionalLanguage.isEmpty()) {
+                if (validLanguageList.contains(languageName)) {
+                    languageList.add(createLanguage(languageName));
+                } else {
+                    throw new LanguageNotValidException(
+                            String.format("Language %s is not valid", languageName));
+                }
+            } else {
+                languageList.add(optionalLanguage.get());
+            }
+        }
+        return languageList;
+    }
+
+    @Override
+    public Language createLanguage(String languageName) {
+        return Language.builder().name(languageName).build();
+    }
+
+    @Override
+    public Optional<Language> findLanguageByName(String languageName) {
+        return languageRepository.findByName(languageName);
+    }
+
+    @Override
+    public List<Language> findLanguagesByNames(List<String> languagesToFind) {
+        List<Language> languagesFound = new ArrayList<>();
+
+        for (String languageName : languagesToFind) {
+            Optional<Language> optionalLanguage = findLanguageByName(languageName);
+            optionalLanguage.ifPresent(languagesFound::add);
+        }
+        return languagesFound;
+    }
+
+    @Override
+    public List<Language> getRemovedLanguages(
+            List<String> updatedLanguages, List<Language> currentLanguages) {
+        List<Language> removedLanguages = new ArrayList<>();
+
+        for (Language language : currentLanguages) {
+            if (!updatedLanguages.contains(language.getName())) {
+                removedLanguages.add(language);
+            }
+        }
+        return removedLanguages;
+    }
+
+    @Override
+    public void deleteUnusedLanguages(List<Language> removedLanguages) {
+        for (Language language : removedLanguages) {
+            if (projectRepository.findProjectsByLanguageName(language.getName()).isEmpty()) {
+                languageRepository.deleteById(language.getId());
+            }
+        }
+    }
+
+    @Override
+    public List<Language> getAllLanguages() {
+        return languageRepository.findAll();
+    }
+
+    @Override
+    public List<String> getValidLanguages() {
+        return validLanguageList;
+    }
+}

--- a/src/main/java/com/a2/backend/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/UserServiceImpl.java
@@ -11,13 +11,12 @@ import com.a2.backend.repository.UserRepository;
 import com.a2.backend.service.ProjectService;
 import com.a2.backend.service.UserService;
 import com.a2.backend.utils.SecurityUtils;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
-import java.util.UUID;
 
 @Service
 public class UserServiceImpl implements UserService {

--- a/src/test/java/com/a2/backend/controller/ProjectControllerTest.java
+++ b/src/test/java/com/a2/backend/controller/ProjectControllerTest.java
@@ -50,6 +50,7 @@ class ProjectControllerTest {
         String description = "Testing exception for existing title";
         List<String> links = Arrays.asList("link1", "link2");
         List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -57,6 +58,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -75,6 +77,7 @@ class ProjectControllerTest {
         String description = "Testing exception for existing title";
         List<String> links = Arrays.asList("link1", "link2");
         List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -82,6 +85,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -101,6 +105,7 @@ class ProjectControllerTest {
         String description = "Short";
         List<String> links = Arrays.asList("link1", "link2");
         List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -108,6 +113,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -127,6 +133,7 @@ class ProjectControllerTest {
         String description = "Short";
         List<String> links = Arrays.asList("link1", "link2");
         List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -134,6 +141,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -159,6 +167,7 @@ class ProjectControllerTest {
         String description = "Testing exception for existing title";
         List<String> links = Arrays.asList("link1", "link2");
         List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -166,6 +175,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -200,6 +210,7 @@ class ProjectControllerTest {
         String description = "Testing exception for existing title";
         List<String> links = Arrays.asList("link1", "link2");
         List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -207,6 +218,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -249,6 +261,7 @@ class ProjectControllerTest {
         String description = "Testing exception for existing title";
         List<String> links = Arrays.asList("link1", "link2");
         List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -256,6 +269,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -300,6 +314,7 @@ class ProjectControllerTest {
         String description = "Testing exception for existing title";
         List<String> links = Arrays.asList("link1", "link2");
         List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         String titleforUpdate = "New Project Title";
         String descriptionforUpdate = "New Project description";
@@ -309,6 +324,7 @@ class ProjectControllerTest {
         List<String> tagsForUpdate = new ArrayList<>();
         tagsForUpdate.add("tag1");
         tagsForUpdate.add("tag2");
+        List<String> languagesForUpdate = Arrays.asList("Python", "PHP");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -316,6 +332,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -325,6 +342,7 @@ class ProjectControllerTest {
                         .description(descriptionforUpdate)
                         .links(linksForUpdate)
                         .tags(tagsForUpdate)
+                        .languages(languagesForUpdate)
                         .build();
 
         HttpEntity<ProjectCreateDTO> request = new HttpEntity<>(projectToCreate);
@@ -358,6 +376,7 @@ class ProjectControllerTest {
         String description = "Testing exception for existing title";
         List<String> links = Arrays.asList("link1", "link2");
         List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -365,6 +384,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -398,6 +418,7 @@ class ProjectControllerTest {
         String description = "description";
         List<String> links = Arrays.asList("link1", "link2");
         List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -405,6 +426,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -432,6 +454,7 @@ class ProjectControllerTest {
         String description = "Testing exception for existing title";
         List<String> links = Arrays.asList("link1", "link2");
         List<String> tags = Arrays.asList("", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -439,6 +462,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -457,6 +481,7 @@ class ProjectControllerTest {
         String description = "Testing exception for existing title";
         List<String> links = Arrays.asList("link1", "link2");
         List<String> tags = Arrays.asList("This is not a valid tag for a project", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -464,6 +489,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -482,6 +508,7 @@ class ProjectControllerTest {
         String description = "Testing exception for existing title";
         List<String> links = List.of();
         List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -489,6 +516,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -507,6 +535,7 @@ class ProjectControllerTest {
         String description = "Testing exception for existing title";
         List<String> links = Arrays.asList("link1", "link2", "link3", "link4", "link5", "link6");
         List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreate =
                 ProjectCreateDTO.builder()
@@ -514,6 +543,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
         HttpEntity<ProjectCreateDTO> request = new HttpEntity<>(projectToCreate);
@@ -535,6 +565,10 @@ class ProjectControllerTest {
         List<String> secondTags = Arrays.asList("tag3", "tag4");
         List<String> thirdTags = Arrays.asList("tag5", "tag6");
         List<String> fourthTags = Arrays.asList("tag7", "tag8");
+        List<String> languages = Arrays.asList("Java", "C");
+        List<String> secondLanguages = Arrays.asList("Java", "Python");
+        List<String> thirdLanguages = Arrays.asList("JavaScript", "C#");
+        List<String> fourthLlanguages = Arrays.asList("TypeScript", "C");
 
         ProjectCreateDTO firstProjectToCreate =
                 ProjectCreateDTO.builder()
@@ -542,6 +576,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
         ProjectCreateDTO secondProjectToCreate =
@@ -550,6 +585,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(secondLinks)
                         .tags(secondTags)
+                        .languages(secondLanguages)
                         .owner(owner)
                         .build();
         ProjectCreateDTO thirdProjectToCreate =
@@ -558,6 +594,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(thirdLinks)
                         .tags(thirdTags)
+                        .languages(thirdLanguages)
                         .owner(owner)
                         .build();
         ProjectCreateDTO fourthProjectToCreate =
@@ -566,6 +603,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(fourthLinks)
                         .tags(fourthTags)
+                        .languages(fourthLlanguages)
                         .owner(owner)
                         .build();
 
@@ -609,6 +647,10 @@ class ProjectControllerTest {
         List<String> secondTags = Arrays.asList("tag3", "tag4");
         List<String> thirdTags = Arrays.asList("tag5", "tag6");
         List<String> fourthTags = Arrays.asList("tag7", "tag8");
+        List<String> languages = Arrays.asList("Java", "C");
+        List<String> secondLanguages = Arrays.asList("Java", "Python");
+        List<String> thirdLanguages = Arrays.asList("JavaScript", "C#");
+        List<String> fourthLlanguages = Arrays.asList("TypeScript", "C");
 
         ProjectCreateDTO firstProjectToCreate =
                 ProjectCreateDTO.builder()
@@ -616,6 +658,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
         ProjectCreateDTO secondProjectToCreate =
@@ -624,6 +667,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(secondLinks)
                         .tags(secondTags)
+                        .languages(secondLanguages)
                         .owner(owner)
                         .build();
         ProjectCreateDTO thirdProjectToCreate =
@@ -632,6 +676,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(thirdLinks)
                         .tags(thirdTags)
+                        .languages(thirdLanguages)
                         .owner(owner)
                         .build();
         ProjectCreateDTO fourthProjectToCreate =
@@ -640,6 +685,7 @@ class ProjectControllerTest {
                         .description(description)
                         .links(fourthLinks)
                         .tags(fourthTags)
+                        .languages(fourthLlanguages)
                         .owner(owner)
                         .build();
 
@@ -667,5 +713,105 @@ class ProjectControllerTest {
         assertEquals(HttpStatus.OK, getResponse.getStatusCode());
         Project[] projects = getResponse.getBody();
         assertEquals(0, projects.length);
+    }
+
+    @Test
+    void Test018_WhenGettingValidLanguagesNameListShouldBeReturned() {
+        String validLanguageNames =
+                "Java, C, C++, C#, Python, Visual Basic .NET, PHP, JavaScript, TypeScript, Delphi/Object Pascal, Swift, Perl, Ruby, Assembly language, R, Visual Basic, Objective-C, Go, MATLAB, PL/SQL, Scratch, SAS, D, Dart, ABAP, COBOL, Ada, Fortran, Transact-SQL, Lua, Scala, Logo, F#, Lisp, LabVIEW, Prolog, Haskell, Scheme, Groovy, RPG (OS/400), Apex, Erlang, MQL4, Rust, Bash, Ladder Logic, Q, Julia, Alice, VHDL, Awk, (Visual) FoxPro, ABC, ActionScript, APL, AutoLISP, bc, BlitzMax, Bourne shell, C shell, CFML, cg, CL (OS/400), Clipper, Clojure, Common Lisp, Crystal, Eiffel, Elixir, Elm, Emacs Lisp, Forth, Hack, Icon, IDL, Inform, Io, J, Korn shell, Kotlin, Maple, ML, NATURAL, NXT-G, OCaml, OpenCL, OpenEdge ABL, Oz, PL/I, PowerShell, REXX, Ring, S, Smalltalk, SPARK, SPSS, Standard ML, Stata, Tcl, VBScript, Verilog";
+        List<String> validLanguageList =
+                new ArrayList<>(Arrays.asList(validLanguageNames.split(", ")));
+
+        val getResponse =
+                restTemplate.exchange("/project/languages", HttpMethod.GET, null, String[].class);
+        assertEquals(HttpStatus.OK, getResponse.getStatusCode());
+        String[] languages = getResponse.getBody();
+
+        assertNotNull(languages);
+        assertEquals(validLanguageList, Arrays.asList(languages));
+    }
+
+    @Test
+    void
+            Test019_ProjectControllerWhenReceiveCreateProjectDTOWithInvalidLanguageShouldReturnStatusBadRequest() {
+        userRepository.save(owner);
+
+        String title = "Project title";
+        String description = "Testing exception for existing title";
+        List<String> links = Arrays.asList("link1", "link2");
+        List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Not Valid Language", "C");
+
+        ProjectCreateDTO projectToCreate =
+                ProjectCreateDTO.builder()
+                        .title(title)
+                        .description(description)
+                        .links(links)
+                        .tags(tags)
+                        .languages(languages)
+                        .owner(owner)
+                        .build();
+
+        HttpEntity<ProjectCreateDTO> request = new HttpEntity<>(projectToCreate);
+
+        val getResponse = restTemplate.exchange(baseUrl, HttpMethod.POST, request, String.class);
+        assertEquals(HttpStatus.BAD_REQUEST, getResponse.getStatusCode());
+        assertEquals("Language Not Valid Language is not valid", getResponse.getBody());
+    }
+
+    @Test
+    void
+            Test020_ProjectControllerWhenReceiveCreateProjectDTOWithMoreThanThreeLanguagesShouldReturnStatusBadRequest() {
+        userRepository.save(owner);
+
+        String title = "Project title";
+        String description = "Testing exception for existing title";
+        List<String> links = Arrays.asList("link1", "link2");
+        List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = Arrays.asList("Java", "C", "Python", "PHP");
+
+        ProjectCreateDTO projectToCreate =
+                ProjectCreateDTO.builder()
+                        .title(title)
+                        .description(description)
+                        .links(links)
+                        .tags(tags)
+                        .languages(languages)
+                        .owner(owner)
+                        .build();
+
+        HttpEntity<ProjectCreateDTO> request = new HttpEntity<>(projectToCreate);
+
+        val getResponse = restTemplate.exchange(baseUrl, HttpMethod.POST, request, String.class);
+        assertEquals(HttpStatus.BAD_REQUEST, getResponse.getStatusCode());
+        assertEquals("Number of languages must be between 1 and 3", getResponse.getBody());
+    }
+
+    @Test
+    void
+            Test020_ProjectControllerWhenReceiveCreateProjectDTOWithNoLanguagesShouldReturnStatusBadRequest() {
+        userRepository.save(owner);
+
+        String title = "Project title";
+        String description = "Testing exception for existing title";
+        List<String> links = Arrays.asList("link1", "link2");
+        List<String> tags = Arrays.asList("tag1", "tag2");
+        List<String> languages = List.of();
+
+        ProjectCreateDTO projectToCreate =
+                ProjectCreateDTO.builder()
+                        .title(title)
+                        .description(description)
+                        .links(links)
+                        .tags(tags)
+                        .languages(languages)
+                        .owner(owner)
+                        .build();
+
+        HttpEntity<ProjectCreateDTO> request = new HttpEntity<>(projectToCreate);
+
+        val getResponse = restTemplate.exchange(baseUrl, HttpMethod.POST, request, String.class);
+        assertEquals(HttpStatus.BAD_REQUEST, getResponse.getStatusCode());
+        assertEquals("Number of languages must be between 1 and 3", getResponse.getBody());
     }
 }

--- a/src/test/java/com/a2/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/a2/backend/controller/UserControllerTest.java
@@ -1,5 +1,8 @@
 package com.a2.backend.controller;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.a2.backend.entity.User;
 import com.a2.backend.model.UserCreateDTO;
 import com.a2.backend.model.UserUpdateDTO;
@@ -20,22 +23,16 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 @AutoConfigureMockMvc
 class UserControllerTest {
 
-    @Autowired
-    TestRestTemplate restTemplate;
+    @Autowired TestRestTemplate restTemplate;
 
-    @Autowired
-    MockMvc mvc;
-    @Autowired
-    ObjectMapper objectMapper;
+    @Autowired MockMvc mvc;
+    @Autowired ObjectMapper objectMapper;
 
     private final String baseUrl = "/user";
     private final String confirmationUrl = "/confirm";
@@ -57,7 +54,7 @@ class UserControllerTest {
 
     @Test
     void
-    Test001_GivenAValidUserCreateDTOWhenRequestingPostThenReturnStatusCreatedAndPersistedUserAreReturned() {
+            Test001_GivenAValidUserCreateDTOWhenRequestingPostThenReturnStatusCreatedAndPersistedUserAreReturned() {
 
         HttpEntity<UserCreateDTO> request = new HttpEntity<>(userCreateDTO);
 
@@ -259,8 +256,8 @@ class UserControllerTest {
     @Test
     @WithMockUser(username = "some@gmail.com")
     void
-    Test011_GivenAValidUserUpdateDTOAndAnExistingUserWhenUpdatingThenAUserWithPreviousNicknameCanBeCreated()
-            throws Exception {
+            Test011_GivenAValidUserUpdateDTOAndAnExistingUserWhenUpdatingThenAUserWithPreviousNicknameCanBeCreated()
+                    throws Exception {
 
         HttpEntity<UserCreateDTO> request = new HttpEntity<>(userCreateDTO);
 
@@ -295,8 +292,8 @@ class UserControllerTest {
     @Test
     @WithMockUser(username = "some@gmail.com")
     void
-    Test012_GivenAUserUpdateDTOWithInvalidNicknameWhenUpdatingUserThenBadStatusResponseIsReturned()
-            throws Exception {
+            Test012_GivenAUserUpdateDTOWithInvalidNicknameWhenUpdatingUserThenBadStatusResponseIsReturned()
+                    throws Exception {
 
         HttpEntity<UserCreateDTO> request = new HttpEntity<>(userCreateDTO);
 
@@ -324,8 +321,8 @@ class UserControllerTest {
     @Test
     @WithMockUser(username = "some@gmail.com")
     void
-    Test013_GivenAUserUpdateDTOWithInvalidPasswordWhenUpdatingUserThenBadStatusResponseIsReturned()
-            throws Exception {
+            Test013_GivenAUserUpdateDTOWithInvalidPasswordWhenUpdatingUserThenBadStatusResponseIsReturned()
+                    throws Exception {
 
         HttpEntity<UserCreateDTO> request = new HttpEntity<>(userCreateDTO);
 
@@ -353,8 +350,8 @@ class UserControllerTest {
     @Test
     @WithMockUser(username = "some@gmail.com")
     void
-    Test014_GivenAUserUpdateDTOWithExistingNicknameWhenUpdatingUserThenExceptionIsHandledAndBadRequestIsReturned()
-            throws Exception {
+            Test014_GivenAUserUpdateDTOWithExistingNicknameWhenUpdatingUserThenExceptionIsHandledAndBadRequestIsReturned()
+                    throws Exception {
 
         HttpEntity<UserCreateDTO> request = new HttpEntity<>(userCreateDTO);
 

--- a/src/test/java/com/a2/backend/repository/LanguageRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/LanguageRepositoryTest.java
@@ -1,0 +1,68 @@
+package com.a2.backend.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.a2.backend.BackendApplication;
+import com.a2.backend.entity.Language;
+import java.util.List;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@AutoConfigureWebClient
+@DataJpaTest
+@ExtendWith(SpringExtension.class)
+@Import({BackendApplication.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+class LanguageRepositoryTest {
+
+    @Autowired private LanguageRepository languageRepository;
+
+    Language language = Language.builder().name("Java").build();
+
+    @Test
+    void Test001_LanguageRepositoryShouldSaveLanguage() {
+
+        assertTrue(languageRepository.findAll().isEmpty());
+
+        assertNull(language.getId());
+        assertEquals("Java", language.getName());
+
+        languageRepository.save(language);
+
+        assertFalse(languageRepository.findAll().isEmpty());
+
+        List<Language> languages = languageRepository.findAll();
+
+        assertEquals(1, languages.size());
+
+        val savedLanguage = languages.get(0);
+
+        assertNotNull(savedLanguage.getId());
+        assertEquals("Java", savedLanguage.getName());
+    }
+
+    @Test
+    void Test002_LanguageRepositoryWhenGivenLanguageNameShouldReturnLanguageWithThatName() {
+
+        languageRepository.save(language);
+
+        assertTrue(languageRepository.findByName("Java").isPresent());
+    }
+
+    @Test
+    void Test003_LanguageRepositoryWhenGivenNonExistingLanguageNameShouldNotReturnLanguage() {
+
+        languageRepository.save(language);
+
+        assertTrue(languageRepository.findByName("Python").isEmpty());
+    }
+}

--- a/src/test/java/com/a2/backend/repository/ProjectRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/ProjectRepositoryTest.java
@@ -3,6 +3,7 @@ package com.a2.backend.repository;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.a2.backend.BackendApplication;
+import com.a2.backend.entity.Language;
 import com.a2.backend.entity.Project;
 import com.a2.backend.entity.Tag;
 import com.a2.backend.entity.User;
@@ -188,5 +189,59 @@ class ProjectRepositoryTest {
         assertEquals(2, projectsWithTag3.size());
         assertTrue(projectsWithTag3.contains(project2));
         assertTrue(projectsWithTag3.contains(project3));
+    }
+
+    @Test
+    void
+            Test007_ProjectRepositoryWhenGivenLanguageNameShouldReturnAllProjectsThatHaveThatLanguage() {
+        userRepository.save(owner);
+
+        Tag tag1 = Tag.builder().name("tag1").build();
+        Tag tag2 = Tag.builder().name("tag2").build();
+        Tag tag3 = Tag.builder().name("tag3").build();
+
+        Language language1 = Language.builder().name("Java").build();
+        Language language2 = Language.builder().name("C").build();
+        Language language3 = Language.builder().name("Python").build();
+
+        Project project1 =
+                Project.builder()
+                        .title("Project1")
+                        .description("My description")
+                        .owner(owner)
+                        .links(Arrays.asList("link1", "link2"))
+                        .tags(Arrays.asList(tag1, tag2))
+                        .languages(Arrays.asList(language1, language2))
+                        .build();
+
+        Project project2 =
+                Project.builder()
+                        .title("Project2")
+                        .description("My description")
+                        .owner(owner)
+                        .links(Arrays.asList("link1", "link2"))
+                        .tags(Arrays.asList(tag1, tag3))
+                        .languages(Arrays.asList(language3, language2))
+                        .build();
+
+        Project project3 =
+                Project.builder()
+                        .title("Project3")
+                        .description("My description")
+                        .owner(owner)
+                        .links(Arrays.asList("link1", "link2"))
+                        .tags(Arrays.asList(tag1, tag3))
+                        .languages(Arrays.asList(language1, language3))
+                        .build();
+
+        projectRepository.save(project1);
+        projectRepository.save(project2);
+        projectRepository.save(project3);
+
+        List<Project> projectsWithLanguage1 = projectRepository.findProjectsByLanguageName("Java");
+
+        assertEquals(2, projectsWithLanguage1.size());
+        assertTrue(projectsWithLanguage1.contains(project1));
+        assertTrue(projectsWithLanguage1.contains(project3));
     }
 }

--- a/src/test/java/com/a2/backend/service/impl/LanguageServiceImplTest.java
+++ b/src/test/java/com/a2/backend/service/impl/LanguageServiceImplTest.java
@@ -1,0 +1,110 @@
+package com.a2.backend.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.a2.backend.entity.Language;
+import com.a2.backend.exception.LanguageNotValidException;
+import com.a2.backend.repository.LanguageRepository;
+import com.a2.backend.service.LanguageService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+class LanguageServiceImplTest {
+
+    @Autowired private LanguageService languageService;
+
+    @Autowired private LanguageRepository languageRepository;
+
+    @Test
+    void Test001_LanguageServiceWhenReceivesValidLanguageNameShouldCreateLanguageWithGivenName() {
+        Language language = languageService.createLanguage("Java");
+
+        assertNull(language.getId());
+        assertEquals("Java", language.getName());
+    }
+
+    @Test
+    void
+            Test002_LanguageServiceWhenReceivesValidLanguageNamesShouldCreateLanguageListWithGivenNames() {
+        List<String> languagesNames = Arrays.asList("Java", "PHP");
+
+        List<Language> languageList = languageService.findOrCreateLanguage(languagesNames);
+
+        assertEquals(2, languageList.size());
+
+        assertEquals("Java", languageList.get(0).getName());
+        assertEquals("PHP", languageList.get(1).getName());
+    }
+
+    @Test
+    void
+            Test003_LanguageServiceGivenAnExistingLanguageWhenTheSameLanguageIsSentTheOldLanguageIsReused() {
+
+        Language language1 = languageRepository.save(languageService.createLanguage("C"));
+
+        List<Language> languageList =
+                languageService.findOrCreateLanguage(Arrays.asList("C", "PHP"));
+
+        assertEquals(2, languageList.size());
+
+        assertEquals(languageList.get(0).getId(), language1.getId());
+    }
+
+    @Test
+    void Test004_LanguageServiceWhenReceivesValidLanguageNameShouldReturnLanguageWithGivenName() {
+
+        Language language1 = languageRepository.save(languageService.createLanguage("Java"));
+        Language language2 = languageRepository.save(languageService.createLanguage("C"));
+
+        List<Language> languages = languageService.findLanguagesByNames(Arrays.asList("Java", "C"));
+
+        assertEquals(2, languages.size());
+        assertTrue(languages.contains(language1));
+        assertTrue(languages.contains(language2));
+    }
+
+    @Test
+    void
+            Test005_LanguageServiceGivenValidLanguageNamesToUpdateAndCurrentLanguagesShouldReturnRemovedLanguages() {
+
+        Language language1 = languageRepository.save(languageService.createLanguage("Java"));
+        Language language2 = languageRepository.save(languageService.createLanguage("C"));
+
+        List<Language> currentLanguages = Arrays.asList(language1, language2);
+        List<String> updatedLanguagesNames = Arrays.asList("PHP", "Java");
+
+        List<Language> removedLanguages =
+                languageService.getRemovedLanguages(updatedLanguagesNames, currentLanguages);
+
+        assertEquals(1, removedLanguages.size());
+        assertEquals("C", removedLanguages.get(0).getName());
+    }
+
+    @Test
+    void Test006_LanguageServiceShouldReturnListWithAllLanguageValidNames() {
+        String validLanguageNames =
+                "Java, C, C++, C#, Python, Visual Basic .NET, PHP, JavaScript, TypeScript, Delphi/Object Pascal, Swift, Perl, Ruby, Assembly language, R, Visual Basic, Objective-C, Go, MATLAB, PL/SQL, Scratch, SAS, D, Dart, ABAP, COBOL, Ada, Fortran, Transact-SQL, Lua, Scala, Logo, F#, Lisp, LabVIEW, Prolog, Haskell, Scheme, Groovy, RPG (OS/400), Apex, Erlang, MQL4, Rust, Bash, Ladder Logic, Q, Julia, Alice, VHDL, Awk, (Visual) FoxPro, ABC, ActionScript, APL, AutoLISP, bc, BlitzMax, Bourne shell, C shell, CFML, cg, CL (OS/400), Clipper, Clojure, Common Lisp, Crystal, Eiffel, Elixir, Elm, Emacs Lisp, Forth, Hack, Icon, IDL, Inform, Io, J, Korn shell, Kotlin, Maple, ML, NATURAL, NXT-G, OCaml, OpenCL, OpenEdge ABL, Oz, PL/I, PowerShell, REXX, Ring, S, Smalltalk, SPARK, SPSS, Standard ML, Stata, Tcl, VBScript, Verilog";
+        List<String> validLanguageList =
+                new ArrayList<>(Arrays.asList(validLanguageNames.split(", ")));
+
+        assertEquals(validLanguageList, languageService.getValidLanguages());
+    }
+
+    @Test
+    void Test007_LanguageServiceWhenReceivesNotValidLanguageNameShouldThrowException() {
+        assertThrows(
+                LanguageNotValidException.class,
+                () ->
+                        languageService.findOrCreateLanguage(
+                                Arrays.asList("Not Valid Name", "Java")));
+    }
+}

--- a/src/test/java/com/a2/backend/service/impl/ProjectServiceImplTest.java
+++ b/src/test/java/com/a2/backend/service/impl/ProjectServiceImplTest.java
@@ -2,6 +2,7 @@ package com.a2.backend.service.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.a2.backend.entity.Language;
 import com.a2.backend.entity.Project;
 import com.a2.backend.entity.Tag;
 import com.a2.backend.entity.User;
@@ -11,8 +12,10 @@ import com.a2.backend.model.ProjectCreateDTO;
 import com.a2.backend.model.ProjectUpdateDTO;
 import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.repository.UserRepository;
+import com.a2.backend.service.LanguageService;
 import com.a2.backend.service.ProjectService;
 import com.a2.backend.service.TagService;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -32,6 +35,8 @@ class ProjectServiceImplTest {
 
     @Autowired private TagService tagService;
 
+    @Autowired private LanguageService languageService;
+
     @Autowired private ProjectRepository projectRepository;
 
     @Autowired private UserRepository userRepository;
@@ -40,6 +45,8 @@ class ProjectServiceImplTest {
     String description = "Testing exception for existing title";
     List<String> links = Arrays.asList("link1", "link2");
     List<String> tags = Arrays.asList("tag1", "tag2");
+    List<String> languages = Arrays.asList("Java", "C");
+
     User owner =
             User.builder()
                     .nickname("nickname")
@@ -50,6 +57,7 @@ class ProjectServiceImplTest {
 
     List<String> linksUpdate = Arrays.asList("link1", "link4");
     List<String> tagsUpdate = Arrays.asList("tag1", "tag4");
+    List<String> languagesUpdate = Arrays.asList("Java", "Ruby");
 
     ProjectCreateDTO projectToCreate =
             ProjectCreateDTO.builder()
@@ -57,6 +65,7 @@ class ProjectServiceImplTest {
                     .description(description)
                     .links(links)
                     .tags(tags)
+                    .languages(languages)
                     .owner(owner)
                     .build();
     ProjectUpdateDTO projectUpdateDTO =
@@ -64,6 +73,7 @@ class ProjectServiceImplTest {
                     .title("new title")
                     .links(linksUpdate)
                     .tags(tagsUpdate)
+                    .languages(languagesUpdate)
                     .description("new description")
                     .build();
 
@@ -85,6 +95,9 @@ class ProjectServiceImplTest {
         assertEquals(projectToCreate.getTitle(), project.getTitle());
         assertEquals(projectToCreate.getDescription(), project.getDescription());
         assertEquals(tagService.findTagsByNames(projectToCreate.getTags()), project.getTags());
+        assertEquals(
+                languageService.findLanguagesByNames(projectToCreate.getLanguages()),
+                project.getLanguages());
         assertEquals(projectToCreate.getLinks(), project.getLinks());
     }
 
@@ -103,6 +116,7 @@ class ProjectServiceImplTest {
                         .description(description2)
                         .links(links)
                         .tags(tags)
+                        .languages(languages)
                         .owner(owner)
                         .build();
 
@@ -123,6 +137,7 @@ class ProjectServiceImplTest {
                                     .description(description)
                                     .links(links)
                                     .tags(tags)
+                                    .languages(languages)
                                     .owner(owner)
                                     .build();
                 });
@@ -151,6 +166,9 @@ class ProjectServiceImplTest {
         assertEquals(projectToCreate.getDescription(), singleProject.getDescription());
         assertEquals(
                 tagService.findTagsByNames(projectToCreate.getTags()), singleProject.getTags());
+        assertEquals(
+                languageService.findLanguagesByNames(projectToCreate.getLanguages()),
+                singleProject.getLanguages());
         assertEquals(projectToCreate.getLinks(), singleProject.getLinks());
     }
 
@@ -238,6 +256,9 @@ class ProjectServiceImplTest {
         assertEquals(
                 tagService.findTagsByNames(projectToCreate.getTags()),
                 projectToBeDisplayed.getTags());
+        assertEquals(
+                languageService.findLanguagesByNames(projectToCreate.getLanguages()),
+                projectToBeDisplayed.getLanguages());
         assertEquals(projectToCreate.getLinks(), projectToBeDisplayed.getLinks());
     }
 
@@ -260,6 +281,7 @@ class ProjectServiceImplTest {
         userRepository.save(owner2);
         List<String> links2 = Arrays.asList("link3", "link4");
         List<String> tags2 = Arrays.asList("tag3", "tag4");
+        List<String> languages2 = Arrays.asList("Java", "C");
 
         ProjectCreateDTO projectToCreateWithRepeatedTitle =
                 ProjectCreateDTO.builder()
@@ -267,6 +289,7 @@ class ProjectServiceImplTest {
                         .description(description2)
                         .links(links2)
                         .tags(tags2)
+                        .languages(languages2)
                         .owner(owner2)
                         .build();
 
@@ -294,6 +317,7 @@ class ProjectServiceImplTest {
                         .description(description)
                         .links(Arrays.asList("link3", "link4"))
                         .tags(Arrays.asList("tag5", "tag7"))
+                        .languages(Arrays.asList("Java", "C"))
                         .owner(owner)
                         .build();
 
@@ -303,6 +327,7 @@ class ProjectServiceImplTest {
                         .description(description)
                         .links(linksUpdate)
                         .tags(tagsUpdate)
+                        .languages(Arrays.asList("Python", "PHP"))
                         .owner(owner)
                         .build();
         // Given
@@ -326,6 +351,7 @@ class ProjectServiceImplTest {
 
         String title2 = "A Non Existent Project title";
         List<String> tags2 = Arrays.asList("tag1", "tag4");
+        List<String> languages2 = Arrays.asList("JavaScript", "Python");
 
         ProjectCreateDTO projectToCreateWithRepeatedTag =
                 ProjectCreateDTO.builder()
@@ -333,6 +359,7 @@ class ProjectServiceImplTest {
                         .description(description)
                         .links(links)
                         .tags(tags2)
+                        .languages(languages2)
                         .owner(owner)
                         .build();
 
@@ -371,5 +398,79 @@ class ProjectServiceImplTest {
         assertEquals(2, updatedTags.size());
         assertEquals("tag1", updatedProject.getTags().get(0).getName());
         assertEquals("tag4", updatedProject.getTags().get(1).getName());
+    }
+
+    @Test
+    void Test015_ProjectServiceShouldReturnListWithAllLanguageValidNames() {
+        String validLanguageNames =
+                "Java, C, C++, C#, Python, Visual Basic .NET, PHP, JavaScript, TypeScript, Delphi/Object Pascal, Swift, Perl, Ruby, Assembly language, R, Visual Basic, Objective-C, Go, MATLAB, PL/SQL, Scratch, SAS, D, Dart, ABAP, COBOL, Ada, Fortran, Transact-SQL, Lua, Scala, Logo, F#, Lisp, LabVIEW, Prolog, Haskell, Scheme, Groovy, RPG (OS/400), Apex, Erlang, MQL4, Rust, Bash, Ladder Logic, Q, Julia, Alice, VHDL, Awk, (Visual) FoxPro, ABC, ActionScript, APL, AutoLISP, bc, BlitzMax, Bourne shell, C shell, CFML, cg, CL (OS/400), Clipper, Clojure, Common Lisp, Crystal, Eiffel, Elixir, Elm, Emacs Lisp, Forth, Hack, Icon, IDL, Inform, Io, J, Korn shell, Kotlin, Maple, ML, NATURAL, NXT-G, OCaml, OpenCL, OpenEdge ABL, Oz, PL/I, PowerShell, REXX, Ring, S, Smalltalk, SPARK, SPSS, Standard ML, Stata, Tcl, VBScript, Verilog";
+        List<String> validLanguageList =
+                new ArrayList<>(Arrays.asList(validLanguageNames.split(", ")));
+
+        assertEquals(validLanguageList, projectService.getValidLanguageNames());
+    }
+
+    @Test
+    void
+            Test014_ProjectServiceWhenReceivesValidProjectUpdateDTOAndIdShouldUpdateProjectAndDeleteUnusedLanguages() {
+        userRepository.save(owner);
+
+        Project createdProject = projectService.createProject(projectToCreate);
+
+        List<Language> languages = languageService.getAllLanguages();
+        assertEquals(2, languages.size());
+        assertEquals("Java", createdProject.getLanguages().get(0).getName());
+        assertEquals("C", createdProject.getLanguages().get(1).getName());
+
+        Project updatedProject =
+                projectService.updateProject(projectUpdateDTO, createdProject.getId());
+
+        assertEquals(createdProject.getId(), updatedProject.getId());
+        assertEquals(projectUpdateDTO.getTitle(), updatedProject.getTitle());
+        assertEquals(projectUpdateDTO.getDescription(), updatedProject.getDescription());
+        assertEquals(tagService.findTagsByNames(tagsUpdate), updatedProject.getTags());
+        assertEquals(
+                languageService.findLanguagesByNames(languagesUpdate),
+                updatedProject.getLanguages());
+        assertEquals(projectUpdateDTO.getLinks(), updatedProject.getLinks());
+
+        List<Language> updatedLanguages = languageService.getAllLanguages();
+        assertEquals(2, updatedLanguages.size());
+        assertEquals("Java", updatedProject.getLanguages().get(0).getName());
+        assertEquals("Ruby", updatedProject.getLanguages().get(1).getName());
+    }
+
+    @Test
+    void
+            Test016_GivenExistingLanguagesAndAValidProjectCreateDTOWhenCreatingProjectThenItIsCreated() {
+        userRepository.save(owner);
+
+        projectService.createProject(projectToCreate);
+
+        String title2 = "A Non Existent Project title";
+        List<String> tags2 = Arrays.asList("tag5", "tag6");
+        List<String> languages2 = Arrays.asList("Java", "Python");
+
+        ProjectCreateDTO projectToCreateWithRepeatedTag =
+                ProjectCreateDTO.builder()
+                        .title(title2)
+                        .description(description)
+                        .links(links)
+                        .tags(tags2)
+                        .languages(languages2)
+                        .owner(owner)
+                        .build();
+
+        val project = projectService.createProject(projectToCreateWithRepeatedTag);
+
+        assertEquals(projectToCreateWithRepeatedTag.getTitle(), project.getTitle());
+        assertEquals(projectToCreateWithRepeatedTag.getDescription(), project.getDescription());
+        assertEquals(
+                tagService.findTagsByNames(projectToCreateWithRepeatedTag.getTags()),
+                project.getTags());
+        assertEquals(
+                languageService.findLanguagesByNames(projectToCreateWithRepeatedTag.getLanguages()),
+                project.getLanguages());
+        assertEquals(projectToCreateWithRepeatedTag.getLinks(), project.getLinks());
     }
 }

--- a/src/test/java/com/a2/backend/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/a2/backend/service/impl/UserServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.a2.backend.service.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.a2.backend.entity.User;
 import com.a2.backend.exception.TokenConfirmationFailedException;
 import com.a2.backend.exception.UserNotFoundException;
@@ -10,6 +12,7 @@ import com.a2.backend.model.UserCreateDTO;
 import com.a2.backend.model.UserUpdateDTO;
 import com.a2.backend.service.ProjectService;
 import com.a2.backend.service.UserService;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -17,20 +20,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 
-import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 class UserServiceImplTest {
 
-    @Autowired
-    private UserService userService;
+    @Autowired private UserService userService;
 
-    @Autowired
-    private ProjectService projectService;
+    @Autowired private ProjectService projectService;
 
     String nickname = "nickname";
     String email = "some@email.com";
@@ -59,7 +56,7 @@ class UserServiceImplTest {
 
     @Test
     void
-    Test001_GivenAValidUserCreateDTOWhenCreatingUserThenThePersistedUserWithHashedPasswordIsReturned() {
+            Test001_GivenAValidUserCreateDTOWhenCreatingUserThenThePersistedUserWithHashedPasswordIsReturned() {
         User persistedApplicationUser = userService.createUser(userCreateDTO);
         assertEquals(nickname, persistedApplicationUser.getNickname());
         assertEquals(email, persistedApplicationUser.getEmail());
@@ -147,6 +144,7 @@ class UserServiceImplTest {
                         .owner(user)
                         .tags(Arrays.asList("tag1", "tag2"))
                         .links(Arrays.asList("link1", "link2"))
+                        .languages(Arrays.asList("Java", "C"))
                         .build());
 
         assertEquals(1, projectService.getAllProjects().size());
@@ -178,7 +176,7 @@ class UserServiceImplTest {
 
     @Test
     void
-    Test009_GivenAnAlreadyActiveUserWhenWantToConfirmThatUserThenThrowTokenConfirmationFailedException() {
+            Test009_GivenAnAlreadyActiveUserWhenWantToConfirmThatUserThenThrowTokenConfirmationFailedException() {
         User user = userService.createUser(userCreateDTO);
         String validToken = "token001";
 
@@ -214,7 +212,7 @@ class UserServiceImplTest {
     @Test
     @WithMockUser(username = "some@email.com")
     void
-    Test010_GivenAUserAndAUserUpdateDTOWithSameNicknameAsBeforeWhenUpdatingUserThenItIsUpdated() {
+            Test010_GivenAUserAndAUserUpdateDTOWithSameNicknameAsBeforeWhenUpdatingUserThenItIsUpdated() {
 
         User persistedApplicationUser = userService.createUser(userCreateDTO);
 
@@ -244,7 +242,7 @@ class UserServiceImplTest {
     @Test
     @WithMockUser(username = "some@email.com")
     void
-    Test012_GivenAUserAndAUserUpdateDTOWithTakenNicknameWhenUpdatingUserThenExceptionIsThrown() {
+            Test012_GivenAUserAndAUserUpdateDTOWithTakenNicknameWhenUpdatingUserThenExceptionIsThrown() {
         userService.createUser(userCreateDTO);
         userService.createUser(
                 UserCreateDTO.builder()


### PR DESCRIPTION
Como dueño de un proyecto quiero poder taggear mi proyecto con un lenguaje de programación para que estén asociados.
UATs:
- Para asociar/desasociar un lenguaje de programación a un proyecto se hace desde la página de alta de proyecto o la de modificación de proyecto.
- Se pueden seleccionar hasta 3 lenguajes de programación por proyecto.
- Los lenguajes admitidos son los siguientes:

Java, C, C++, C#, Python, Visual Basic .NET, PHP, JavaScript, TypeScript, Delphi/Object Pascal, Swift, Perl, Ruby, Assembly language, R, Visual Basic, Objective-C, Go, MATLAB, PL/SQL, Scratch, SAS, D, Dart, ABAP, COBOL, Ada, Fortran, Transact-SQL, Lua, Scala, Logo, F#, Lisp, LabVIEW, Prolog, Haskell, Scheme, Groovy, RPG (OS/400), Apex, Erlang, MQL4, Rust, Bash, Ladder Logic, Q, Julia, Alice, VHDL, Awk, (Visual) FoxPro, ABC, ActionScript, APL, AutoLISP, bc, BlitzMax, Bourne shell, C shell, CFML, cg, CL (OS/400), Clipper, Clojure, Common Lisp, Crystal, Eiffel, Elixir, Elm, Emacs Lisp, Forth, Hack, Icon, IDL, Inform, Io, J, Korn shell, Kotlin, Maple, ML, NATURAL, NXT-G, OCaml, OpenCL, OpenEdge ABL, Oz, PL/I, PowerShell, REXX, Ring, S, Smalltalk, SPARK, SPSS, Standard ML, Stata, Tcl, VBScript, Verilog

Esta historia requiere:
- Agregar un endpoint donde se pueda acceder la lista de lenguajes
- Agregar al proyecto un lista de lenguajes. La entidad Language se comporta exactamente igual que la entidad Tag