### PR TITLE
US-6.1.1.1/guardar-preferencias

### DIFF
--- a/src/main/java/com/a2/backend/controller/UserController.java
+++ b/src/main/java/com/a2/backend/controller/UserController.java
@@ -4,16 +4,18 @@ import com.a2.backend.constants.SecurityConstants;
 import com.a2.backend.entity.User;
 import com.a2.backend.model.PasswordRecoveryDTO;
 import com.a2.backend.model.PasswordRecoveryInitDTO;
+import com.a2.backend.model.PreferencesUpdateDTO;
 import com.a2.backend.model.UserCreateDTO;
 import com.a2.backend.model.UserUpdateDTO;
 import com.a2.backend.service.UserService;
-import java.util.UUID;
-import javax.validation.Valid;
 import lombok.val;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/user")
@@ -62,6 +64,14 @@ public class UserController {
     @PutMapping
     public ResponseEntity<?> updateUser(@Valid @RequestBody UserUpdateDTO userUpdateDTO) {
         User updatedUser = userService.updateUser(userUpdateDTO);
+        return ResponseEntity.status(HttpStatus.OK).body(updatedUser);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @PutMapping("/preferences")
+    public ResponseEntity<?> updatePreferences(
+            @Valid @RequestBody PreferencesUpdateDTO preferencesUpdateDTO) {
+        User updatedUser = userService.updatePreferences(preferencesUpdateDTO);
         return ResponseEntity.status(HttpStatus.OK).body(updatedUser);
     }
 }

--- a/src/main/java/com/a2/backend/entity/User.java
+++ b/src/main/java/com/a2/backend/entity/User.java
@@ -1,9 +1,13 @@
 package com.a2.backend.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import java.util.UUID;
-import javax.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
+
+import javax.persistence.*;
+import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -28,6 +32,14 @@ public class User {
     String biography;
 
     String password; // Hashed
+
+    @ElementCollection
+    @LazyCollection(LazyCollectionOption.FALSE)
+    private List<String> preferredTags;
+
+    @ElementCollection
+    @LazyCollection(LazyCollectionOption.FALSE)
+    private List<String> preferredLanguages;
 
     @JsonIgnore String confirmationToken;
 

--- a/src/main/java/com/a2/backend/model/PreferencesUpdateDTO.java
+++ b/src/main/java/com/a2/backend/model/PreferencesUpdateDTO.java
@@ -1,0 +1,24 @@
+package com.a2.backend.model;
+
+import lombok.*;
+import org.hibernate.validator.constraints.UniqueElements;
+
+import javax.validation.constraints.Size;
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PreferencesUpdateDTO {
+
+    @UniqueElements(message = "Tag names must be unique")
+    @Size(max = 4, message = "Maximum number of tags is 4")
+    List<String> tags;
+
+    @UniqueElements(message = "Languages must be unique")
+    @Size(max = 3, message = "Maximum number of languages is 3")
+    List<String> languages;
+}

--- a/src/main/java/com/a2/backend/service/UserService.java
+++ b/src/main/java/com/a2/backend/service/UserService.java
@@ -3,8 +3,10 @@ package com.a2.backend.service;
 import com.a2.backend.entity.User;
 import com.a2.backend.model.PasswordRecoveryDTO;
 import com.a2.backend.model.PasswordRecoveryInitDTO;
+import com.a2.backend.model.PreferencesUpdateDTO;
 import com.a2.backend.model.UserCreateDTO;
 import com.a2.backend.model.UserUpdateDTO;
+
 import java.util.UUID;
 
 public interface UserService {
@@ -20,4 +22,6 @@ public interface UserService {
     User updateUser(UserUpdateDTO userUpdateDTO);
 
     void sendPasswordRecoveryMail(PasswordRecoveryInitDTO passwordRecoveryInitDTO);
+
+    User updatePreferences(PreferencesUpdateDTO preferencesUpdateDTO);
 }

--- a/src/main/java/com/a2/backend/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/ProjectServiceImpl.java
@@ -12,16 +12,17 @@ import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.service.LanguageService;
 import com.a2.backend.service.ProjectService;
 import com.a2.backend.service.TagService;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import javax.transaction.Transactional;
 import lombok.val;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 public class ProjectServiceImpl implements ProjectService {
@@ -46,7 +47,11 @@ public class ProjectServiceImpl implements ProjectService {
     public Project createProject(ProjectCreateDTO projectCreateDTO) {
         val existingProjectWithTitle = projectRepository.findByTitle(projectCreateDTO.getTitle());
         if (existingProjectWithTitle.isEmpty()
-                || !existingProjectWithTitle.get().getOwner().equals(projectCreateDTO.getOwner())) {
+                || !existingProjectWithTitle
+                .get()
+                .getOwner()
+                .getId()
+                .equals(projectCreateDTO.getOwner().getId())) {
 
             List<Tag> tags = tagService.findOrCreateTag(projectCreateDTO.getTags());
             List<Language> languages =

--- a/src/main/java/com/a2/backend/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/UserServiceImpl.java
@@ -4,6 +4,7 @@ import com.a2.backend.entity.User;
 import com.a2.backend.exception.*;
 import com.a2.backend.model.PasswordRecoveryDTO;
 import com.a2.backend.model.PasswordRecoveryInitDTO;
+import com.a2.backend.model.PreferencesUpdateDTO;
 import com.a2.backend.model.UserCreateDTO;
 import com.a2.backend.model.UserUpdateDTO;
 import com.a2.backend.repository.UserRepository;
@@ -12,12 +13,12 @@ import com.a2.backend.service.ProjectService;
 import com.a2.backend.service.UserService;
 import com.a2.backend.utils.RandomStringUtils;
 import com.a2.backend.utils.SecurityUtils;
-import java.util.Optional;
-import java.util.UUID;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.*;
 
 @Service
 public class UserServiceImpl implements UserService {
@@ -27,7 +28,14 @@ public class UserServiceImpl implements UserService {
     private final ProjectService projectService;
     private final MailService mailService;
 
-    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private final String validLanguageNames =
+            "Java, C, C++, C#, Python, Visual Basic .NET, PHP, JavaScript, TypeScript, Delphi/Object Pascal, Swift, Perl, Ruby, Assembly language, R, Visual Basic, Objective-C, Go, MATLAB, PL/SQL, Scratch, SAS, D, Dart, ABAP, COBOL, Ada, Fortran, Transact-SQL, Lua, Scala, Logo, F#, Lisp, LabVIEW, Prolog, Haskell, Scheme, Groovy, RPG (OS/400), Apex, Erlang, MQL4, Rust, Bash, Ladder Logic, Q, Julia, Alice, VHDL, Awk, (Visual) FoxPro, ABC, ActionScript, APL, AutoLISP, bc, BlitzMax, Bourne shell, C shell, CFML, cg, CL (OS/400), Clipper, Clojure, Common Lisp, Crystal, Eiffel, Elixir, Elm, Emacs Lisp, Forth, Hack, Icon, IDL, Inform, Io, J, Korn shell, Kotlin, Maple, ML, NATURAL, NXT-G, OCaml, OpenCL, OpenEdge ABL, Oz, PL/I, PowerShell, REXX, Ring, S, Smalltalk, SPARK, SPSS, Standard ML, Stata, Tcl, VBScript, Verilog";
+
+    private final List<String> validLanguageList =
+            new ArrayList<>(Arrays.asList(validLanguageNames.split(", ")));
 
     public UserServiceImpl(
             UserRepository userRepository, ProjectService projectService, MailService mailService) {
@@ -83,6 +91,22 @@ public class UserServiceImpl implements UserService {
         loggedUser.setNickname(userUpdateDTO.getNickname());
         loggedUser.setBiography(userUpdateDTO.getBiography());
         loggedUser.setPassword(passwordEncoder.encode(userUpdateDTO.getPassword()));
+        return userRepository.save(loggedUser);
+    }
+
+    @Override
+    public User updatePreferences(PreferencesUpdateDTO preferencesUpdateDTO) {
+        User loggedUser = getLoggedUser();
+
+        for (String language : preferencesUpdateDTO.getLanguages()) {
+            if (!validLanguageList.contains(language))
+                throw new LanguageNotValidException(
+                        String.format("Language %s is not valid", language));
+        }
+
+        loggedUser.setPreferredLanguages(preferencesUpdateDTO.getLanguages());
+        loggedUser.setPreferredTags(preferencesUpdateDTO.getTags());
+
         return userRepository.save(loggedUser);
     }
 

--- a/src/test/java/com/a2/backend/service/impl/ProjectServiceImplTest.java
+++ b/src/test/java/com/a2/backend/service/impl/ProjectServiceImplTest.java
@@ -1,7 +1,5 @@
 package com.a2.backend.service.impl;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import com.a2.backend.entity.Language;
 import com.a2.backend.entity.Project;
 import com.a2.backend.entity.Tag;
@@ -15,16 +13,19 @@ import com.a2.backend.repository.UserRepository;
 import com.a2.backend.service.LanguageService;
 import com.a2.backend.service.ProjectService;
 import com.a2.backend.service.TagService;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
 import lombok.val;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
@@ -53,6 +54,8 @@ class ProjectServiceImplTest {
                     .email("some@email.com")
                     .biography("bio")
                     .password("password")
+                    .preferredLanguages(List.of("Java", "C"))
+                    .preferredTags(List.of("tag1", "tag3"))
                     .build();
 
     List<String> linksUpdate = Arrays.asList("link1", "link4");
@@ -99,6 +102,19 @@ class ProjectServiceImplTest {
                 languageService.findLanguagesByNames(projectToCreate.getLanguages()),
                 project.getLanguages());
         assertEquals(projectToCreate.getLinks(), project.getLinks());
+
+        // The whole owner is the same but when the project is persisted the persisted owner is
+        // merged and thus .equals() returns false.
+        // The same happens with preferred tags and languages collections.
+        assertEquals(owner.getId(), project.getOwner().getId());
+        assertEquals(owner.getNickname(), project.getOwner().getNickname());
+        assertEquals(owner.getEmail(), project.getOwner().getEmail());
+        assertEquals(owner.getPassword(), project.getOwner().getPassword());
+        assertEquals(owner.getBiography(), project.getOwner().getBiography());
+        assertTrue(
+                owner.getPreferredLanguages()
+                        .containsAll(project.getOwner().getPreferredLanguages()));
+        assertTrue(owner.getPreferredTags().containsAll(project.getOwner().getPreferredTags()));
     }
 
     @Test
@@ -250,7 +266,7 @@ class ProjectServiceImplTest {
         val projectToBeDisplayed = projectService.getProjectDetails(project.getId());
 
         assertEquals(project.getId(), projectToBeDisplayed.getId());
-        assertEquals(projectToCreate.getOwner(), projectToBeDisplayed.getOwner());
+        assertEquals(projectToCreate.getOwner().getId(), projectToBeDisplayed.getOwner().getId());
         assertEquals(projectToCreate.getTitle(), projectToBeDisplayed.getTitle());
         assertEquals(projectToCreate.getDescription(), projectToBeDisplayed.getDescription());
         assertEquals(


### PR DESCRIPTION
Como usuario quiero poder guardar mis preferencias de lenguaje y tags para que se me muestren proyectos relacionados.

Endpoint: /user/preferences

UATs:
- DTO con tags y lenguajes
- La configuración debe poder aceptar hasta 3 lenguajes de programación
- La configuración debe poder aceptar hasta 4 tags
- Los tags y lenguajes se guardan como string, no como entities. Permitiendo almacenar tags inexistentes. Los lenguajes deben existir (Ver US Tags de Lenguajes para ver la lista completa)
