### PR TITLE
Added feature perfil de usuario

### DIFF
--- a/src/main/java/com/a2/backend/DemoRunner.java
+++ b/src/main/java/com/a2/backend/DemoRunner.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.core.env.Environment;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,7 +29,10 @@ public class DemoRunner implements CommandLineRunner {
 
     @Autowired private Environment env;
     @Autowired private ProjectRepository projectRepository;
-    @Autowired private UserRepository userRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     public DemoRunner() {}
 
@@ -66,7 +70,7 @@ public class DemoRunner implements CommandLineRunner {
                 User.builder()
                         .nickname("Peltevis")
                         .email("agustin.ayerza@ing.austral.edu.ar")
-                        .password("password")
+                        .password(passwordEncoder.encode("password"))
                         .preferredTags(List.of("GNU", "MATLAB"))
                         .confirmationToken("token001")
                         .collaboratedProjectsPrivacy(PrivacyConstant.PRIVATE)
@@ -79,7 +83,7 @@ public class DemoRunner implements CommandLineRunner {
                         .email("rodrigo.pazos@ing.austral.edu.ar")
                         .biography(
                                 "Backend software engineer, passionate about design and clean code. Working with Java, Python and Scala. ")
-                        .password("password")
+                        .password(passwordEncoder.encode("password"))
                         .confirmationToken("token002")
                         .isActive(true)
                         .build();
@@ -89,7 +93,7 @@ public class DemoRunner implements CommandLineRunner {
                         .email("fabrizio.disanto@ing.austral.edu.ar")
                         .biography(
                                 "Software Engineer student, currently working as a full-stack developer. ")
-                        .password("password")
+                        .password(passwordEncoder.encode("password"))
                         .confirmationToken("token003")
                         .languagesPrivacy(PrivacyConstant.PRIVATE)
                         .collaboratedProjectsPrivacy(PrivacyConstant.PRIVATE)

--- a/src/main/java/com/a2/backend/DemoRunner.java
+++ b/src/main/java/com/a2/backend/DemoRunner.java
@@ -1,15 +1,13 @@
 package com.a2.backend;
 
 import com.a2.backend.annotation.Generated;
+import com.a2.backend.constants.PrivacyConstant;
 import com.a2.backend.entity.Language;
 import com.a2.backend.entity.Project;
 import com.a2.backend.entity.Tag;
 import com.a2.backend.entity.User;
 import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.repository.UserRepository;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +15,10 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component("DemoRunner")
 @Transactional
@@ -65,7 +67,10 @@ public class DemoRunner implements CommandLineRunner {
                         .nickname("Peltevis")
                         .email("agustin.ayerza@ing.austral.edu.ar")
                         .password("password")
+                        .preferredTags(List.of("GNU", "MATLAB"))
                         .confirmationToken("token001")
+                        .collaboratedProjectsPrivacy(PrivacyConstant.PRIVATE)
+                        .languagesPrivacy(PrivacyConstant.PRIVATE)
                         .isActive(true)
                         .build();
         User rodrigo =
@@ -86,6 +91,10 @@ public class DemoRunner implements CommandLineRunner {
                                 "Software Engineer student, currently working as a full-stack developer. ")
                         .password("password")
                         .confirmationToken("token003")
+                        .languagesPrivacy(PrivacyConstant.PRIVATE)
+                        .collaboratedProjectsPrivacy(PrivacyConstant.PRIVATE)
+                        .ownedProjectsPrivacy(PrivacyConstant.PRIVATE)
+                        .tagsPrivacy(PrivacyConstant.PRIVATE)
                         .build();
         userRepository.save(agustin);
         userRepository.save(rodrigo);
@@ -244,7 +253,7 @@ public class DemoRunner implements CommandLineRunner {
                         .owner(userRepository.findByNickname("ropa1998").get())
                         .languages(
                                 listOf(
-                                        Language.builder().name("JavaSript").build(),
+                                        Language.builder().name("JavaScript").build(),
                                         Language.builder().name("TypeScript").build()))
                         .featured(true)
                         .collaborators(List.of())

--- a/src/main/java/com/a2/backend/constants/PrivacyConstant.java
+++ b/src/main/java/com/a2/backend/constants/PrivacyConstant.java
@@ -1,0 +1,6 @@
+package com.a2.backend.constants;
+
+public enum PrivacyConstant {
+    PRIVATE,
+    PUBLIC
+}

--- a/src/main/java/com/a2/backend/controller/UserController.java
+++ b/src/main/java/com/a2/backend/controller/UserController.java
@@ -4,13 +4,15 @@ import com.a2.backend.constants.SecurityConstants;
 import com.a2.backend.entity.User;
 import com.a2.backend.model.*;
 import com.a2.backend.service.UserService;
-import java.util.List;
-import javax.validation.Valid;
 import lombok.val;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/user")
@@ -66,7 +68,7 @@ public class UserController {
     @Secured({SecurityConstants.USER_ROLE})
     @PutMapping
     public ResponseEntity<?> updateUser(@Valid @RequestBody UserUpdateDTO userUpdateDTO) {
-        User updatedUser = userService.updateUser(userUpdateDTO);
+        val updatedUser = userService.updateUser(userUpdateDTO);
         return ResponseEntity.status(HttpStatus.OK).body(updatedUser);
     }
 
@@ -74,13 +76,28 @@ public class UserController {
     @PutMapping("/preferences")
     public ResponseEntity<?> updatePreferences(
             @Valid @RequestBody PreferencesUpdateDTO preferencesUpdateDTO) {
-        User updatedUser = userService.updatePreferences(preferencesUpdateDTO);
+        val updatedUser = userService.updatePreferences(preferencesUpdateDTO);
+        return ResponseEntity.status(HttpStatus.OK).body(updatedUser);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @PutMapping("/privacy")
+    public ResponseEntity<?> updatePrivacySettings(
+            @Valid @RequestBody UserPrivacyDTO userPrivacyDTO) {
+        val updatedUser = userService.updatePrivacySettings(userPrivacyDTO);
         return ResponseEntity.status(HttpStatus.OK).body(updatedUser);
     }
 
     @GetMapping("/preferences")
-    public ResponseEntity<List<ProjectDTO>> getPreferedProjects() {
-        val preferedProjects = userService.getPreferredProjects();
-        return ResponseEntity.status(HttpStatus.OK).body(preferedProjects);
+    public ResponseEntity<List<ProjectDTO>> getPreferredProjects() {
+        val preferredProjects = userService.getPreferredProjects();
+        return ResponseEntity.status(HttpStatus.OK).body(preferredProjects);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getUserProfile(@PathVariable UUID id) {
+        val userProfile = userService.getUserProfile(id);
+        return ResponseEntity.status(HttpStatus.OK).body(userProfile);
     }
 }

--- a/src/main/java/com/a2/backend/entity/User.java
+++ b/src/main/java/com/a2/backend/entity/User.java
@@ -1,13 +1,15 @@
 package com.a2.backend.entity;
 
+import com.a2.backend.constants.PrivacyConstant;
 import com.a2.backend.model.ProjectUserDTO;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import java.util.List;
-import java.util.UUID;
-import javax.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
+
+import javax.persistence.*;
+import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -31,7 +33,8 @@ public class User {
 
     String biography;
 
-    @JsonIgnore String password; // Hashed
+    @JsonIgnore
+    String password; // Hashed
 
     @ElementCollection
     @LazyCollection(LazyCollectionOption.FALSE)
@@ -41,11 +44,26 @@ public class User {
     @LazyCollection(LazyCollectionOption.FALSE)
     private List<String> preferredLanguages;
 
-    @JsonIgnore String confirmationToken;
+    @Builder.Default
+    private PrivacyConstant tagsPrivacy = PrivacyConstant.PUBLIC;
 
-    @JsonIgnore String passwordRecoveryToken;
+    @Builder.Default
+    private PrivacyConstant languagesPrivacy = PrivacyConstant.PUBLIC;
 
-    @Builder.Default boolean isActive = false;
+    @Builder.Default
+    private PrivacyConstant ownedProjectsPrivacy = PrivacyConstant.PUBLIC;
+
+    @Builder.Default
+    private PrivacyConstant collaboratedProjectsPrivacy = PrivacyConstant.PUBLIC;
+
+    @JsonIgnore
+    String confirmationToken;
+
+    @JsonIgnore
+    String passwordRecoveryToken;
+
+    @Builder.Default
+    boolean isActive = false;
 
     public ProjectUserDTO toDTO() {
         return ProjectUserDTO.builder().id(id).nickname(nickname).email(email).build();

--- a/src/main/java/com/a2/backend/model/UserPrivacyDTO.java
+++ b/src/main/java/com/a2/backend/model/UserPrivacyDTO.java
@@ -1,0 +1,27 @@
+package com.a2.backend.model;
+
+import com.a2.backend.constants.PrivacyConstant;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPrivacyDTO {
+
+    @NotNull
+    private PrivacyConstant tagsPrivacy;
+
+    @NotNull
+    private PrivacyConstant languagesPrivacy;
+
+    @NotNull
+    private PrivacyConstant ownedProjectsPrivacy;
+
+    @NotNull
+    private PrivacyConstant collaboratedProjectsPrivacy;
+}

--- a/src/main/java/com/a2/backend/model/UserProfileDTO.java
+++ b/src/main/java/com/a2/backend/model/UserProfileDTO.java
@@ -1,0 +1,32 @@
+package com.a2.backend.model;
+
+import lombok.*;
+import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileDTO {
+
+    @NotNull String nickname;
+
+    @NotNull String biography;
+
+    @Nullable
+    List<String> preferredTags;
+
+    @Nullable
+    List<String> preferredLanguages;
+
+    @Nullable
+    List<ProjectDTO> ownedProjects;
+
+    @Nullable
+    List<ProjectDTO> collaboratedProjects;
+}

--- a/src/main/java/com/a2/backend/repository/ProjectRepository.java
+++ b/src/main/java/com/a2/backend/repository/ProjectRepository.java
@@ -2,11 +2,12 @@ package com.a2.backend.repository;
 
 import com.a2.backend.entity.Project;
 import com.a2.backend.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface ProjectRepository extends JpaRepository<Project, UUID> {
 
@@ -25,4 +26,6 @@ public interface ProjectRepository extends JpaRepository<Project, UUID> {
     List<Project> findAllByFeaturedIsTrue();
 
     List<Project> findByOwner(User user);
+
+    List<Project> findByCollaboratorsContaining(User user);
 }

--- a/src/main/java/com/a2/backend/service/ProjectService.java
+++ b/src/main/java/com/a2/backend/service/ProjectService.java
@@ -6,6 +6,7 @@ import com.a2.backend.model.ProjectCreateDTO;
 import com.a2.backend.model.ProjectDTO;
 import com.a2.backend.model.ProjectSearchDTO;
 import com.a2.backend.model.ProjectUpdateDTO;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -32,4 +33,8 @@ public interface ProjectService {
     List<Project> getMyProjects();
 
     ProjectDTO applyToProject(UUID projectToApplyID);
+
+    List<Project> getProjectsByOwner(User owner);
+
+    List<Project> getCollaboratingProjects(User user);
 }

--- a/src/main/java/com/a2/backend/service/UserService.java
+++ b/src/main/java/com/a2/backend/service/UserService.java
@@ -2,8 +2,10 @@ package com.a2.backend.service;
 
 import com.a2.backend.entity.User;
 import com.a2.backend.model.*;
+
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface UserService {
 
@@ -26,4 +28,8 @@ public interface UserService {
     List<ProjectDTO> getPreferredProjects();
 
     Optional<User> getUser();
+
+    User updatePrivacySettings(UserPrivacyDTO userPrivacyDTO);
+
+    UserProfileDTO getUserProfile(UUID id);
 }

--- a/src/main/java/com/a2/backend/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/ProjectServiceImpl.java
@@ -18,10 +18,11 @@ import com.a2.backend.service.LanguageService;
 import com.a2.backend.service.ProjectService;
 import com.a2.backend.service.TagService;
 import com.a2.backend.service.UserService;
-import java.util.*;
-import javax.transaction.Transactional;
 import lombok.val;
 import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.*;
 
 @Service
 public class ProjectServiceImpl implements ProjectService {
@@ -298,5 +299,15 @@ public class ProjectServiceImpl implements ProjectService {
         project.setApplicants(applicants);
 
         return projectRepository.save(project).toDTO();
+    }
+
+    @Override
+    public List<Project> getProjectsByOwner(User owner) {
+        return projectRepository.findByOwner(owner);
+    }
+
+    @Override
+    public List<Project> getCollaboratingProjects(User user) {
+        return projectRepository.findByCollaboratorsContaining(user);
     }
 }

--- a/src/test/java/com/a2/backend/controller/UserControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/UserControllerActiveTest.java
@@ -1,0 +1,144 @@
+package com.a2.backend.controller;
+
+import com.a2.backend.constants.PrivacyConstant;
+import com.a2.backend.entity.User;
+import com.a2.backend.model.UserPrivacyDTO;
+import com.a2.backend.model.UserProfileDTO;
+import com.a2.backend.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+public class UserControllerActiveTest extends AbstractControllerTest {
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    UserRepository userRepository;
+
+    private final String baseUrl = "/user";
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void
+    Test001_UserControllerWhenUpdatingUserPreferencesThenTheyStatusIsOkAndUpdatedUserIsReturned()
+            throws Exception {
+        UserPrivacyDTO privacyDTO =
+                UserPrivacyDTO.builder()
+                        .tagsPrivacy(PrivacyConstant.PRIVATE)
+                        .collaboratedProjectsPrivacy(PrivacyConstant.PRIVATE)
+                        .languagesPrivacy(PrivacyConstant.PRIVATE)
+                        .ownedProjectsPrivacy(PrivacyConstant.PRIVATE)
+                        .build();
+
+        String contentAsString =
+                mvc.perform(
+                                MockMvcRequestBuilders.put(baseUrl + "/privacy")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(privacyDTO))
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        User updatedUser = objectMapper.readValue(contentAsString, User.class);
+
+        assertEquals(PrivacyConstant.PRIVATE, updatedUser.getTagsPrivacy());
+        assertEquals(PrivacyConstant.PRIVATE, updatedUser.getLanguagesPrivacy());
+        assertEquals(PrivacyConstant.PRIVATE, updatedUser.getCollaboratedProjectsPrivacy());
+        assertEquals(PrivacyConstant.PRIVATE, updatedUser.getOwnedProjectsPrivacy());
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void
+    Test002_UserControllerWhenGettingUserProfileThenStatusIsOkAndProfileWithPublicFieldsIsReturned()
+            throws Exception {
+        User user = userRepository.findByEmail("rodrigo.pazos@ing.austral.edu.ar").get();
+
+        String contentAsString =
+                mvc.perform(
+                                MockMvcRequestBuilders.get(
+                                                String.format("%s/%s", baseUrl, user.getId()))
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        UserProfileDTO userProfile = objectMapper.readValue(contentAsString, UserProfileDTO.class);
+
+        assertEquals(user.getNickname(), userProfile.getNickname());
+        assertEquals(user.getBiography(), userProfile.getBiography());
+        assertNotNull(userProfile.getPreferredTags());
+        assertTrue(user.getPreferredTags().containsAll(userProfile.getPreferredTags()));
+        assertNotNull(userProfile.getOwnedProjects());
+        assertEquals(4, userProfile.getOwnedProjects().size());
+        assertNotNull(userProfile.getCollaboratedProjects());
+        assertEquals(2, userProfile.getCollaboratedProjects().size());
+        assertNotNull(userProfile.getPreferredLanguages());
+        assertTrue(user.getPreferredLanguages().containsAll(userProfile.getPreferredLanguages()));
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void
+    Test003_UserControllerWhenGettingUserProfileThenStatusIsOkAndProfileWithNullOnPrivateFieldsIsReturned()
+            throws Exception {
+        User user = userRepository.findByEmail("agustin.ayerza@ing.austral.edu.ar").get();
+
+        String contentAsString =
+                mvc.perform(
+                                MockMvcRequestBuilders.get(
+                                                String.format("%s/%s", baseUrl, user.getId()))
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        UserProfileDTO userProfile = objectMapper.readValue(contentAsString, UserProfileDTO.class);
+
+        assertEquals(user.getNickname(), userProfile.getNickname());
+        assertEquals(user.getBiography(), userProfile.getBiography());
+        assertNotNull(userProfile.getPreferredTags());
+        assertTrue(user.getPreferredTags().containsAll(userProfile.getPreferredTags()));
+        assertNotNull(userProfile.getOwnedProjects());
+        assertEquals(3, userProfile.getOwnedProjects().size());
+        assertNull(userProfile.getCollaboratedProjects());
+        assertNull(userProfile.getPreferredLanguages());
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void Test004_UserControllerWhenGettingUserProfileForNonExistentUserThenBadRequestIsReturned()
+            throws Exception {
+        String errorMessage =
+                mvc.perform(
+                                MockMvcRequestBuilders.get(
+                                                String.format("%s/%s", baseUrl, UUID.randomUUID()))
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isBadRequest())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        assert (Objects.requireNonNull(errorMessage).contains("There is no user with id"));
+    }
+}

--- a/src/test/java/com/a2/backend/service/impl/ProjectServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/ProjectServiceActiveTest.java
@@ -1,7 +1,5 @@
 package com.a2.backend.service.impl;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import com.a2.backend.entity.Project;
 import com.a2.backend.entity.User;
 import com.a2.backend.exception.InvalidProjectCollaborationApplicationException;
@@ -9,17 +7,23 @@ import com.a2.backend.model.ProjectSearchDTO;
 import com.a2.backend.model.ProjectUserDTO;
 import com.a2.backend.service.ProjectService;
 import com.a2.backend.service.UserService;
-import java.util.stream.Collectors;
 import lombok.val;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 public class ProjectServiceActiveTest extends AbstractServiceTest {
 
-    @Autowired private ProjectService projectService;
+    @Autowired
+    private ProjectService projectService;
 
-    @Autowired private UserService userService;
+    @Autowired
+    private UserService userService;
 
     @Test
     @WithMockUser(username = "fabrizio.disanto@ing.austral.edu.ar")
@@ -91,5 +95,54 @@ public class ProjectServiceActiveTest extends AbstractServiceTest {
         assertThrows(
                 InvalidProjectCollaborationApplicationException.class,
                 () -> projectService.applyToProject(project.getId()));
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void
+    Test006_ProjectServiceWhenFindingProjectsByCollaboratorsContainingUserThenProjectsAreReturned() {
+        List<Project> collaboratingProjects =
+                projectService.getCollaboratingProjects(userService.getLoggedUser());
+
+        assertEquals(2, collaboratingProjects.size());
+
+        ProjectSearchDTO projectSearchDTO = ProjectSearchDTO.builder().title("Node.js").build();
+        Project project = projectService.searchProjecsByFilter(projectSearchDTO).get(0);
+
+        assertTrue(collaboratingProjects.contains(project));
+
+        projectSearchDTO.setTitle("Django");
+        project = projectService.searchProjecsByFilter(projectSearchDTO).get(0);
+
+        assertTrue(collaboratingProjects.contains(project));
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void Test007_ProjectServiceWhenFindingProjectsByOwnerThenProjectsAreReturned() {
+        List<Project> ownedProjects =
+                projectService.getProjectsByOwner(userService.getLoggedUser());
+
+        assertEquals(4, ownedProjects.size());
+
+        ProjectSearchDTO projectSearchDTO = ProjectSearchDTO.builder().title("TensorFlow").build();
+        Project project = projectService.searchProjecsByFilter(projectSearchDTO).get(0);
+
+        assertTrue(ownedProjects.contains(project));
+
+        projectSearchDTO.setTitle("Renovate");
+        project = projectService.searchProjecsByFilter(projectSearchDTO).get(0);
+
+        assertTrue(ownedProjects.contains(project));
+
+        projectSearchDTO.setTitle("Kubernetes");
+        project = projectService.searchProjecsByFilter(projectSearchDTO).get(0);
+
+        assertTrue(ownedProjects.contains(project));
+
+        projectSearchDTO.setTitle("RedHatAnsible");
+        project = projectService.searchProjecsByFilter(projectSearchDTO).get(0);
+
+        assertTrue(ownedProjects.contains(project));
     }
 }

--- a/src/test/java/com/a2/backend/service/impl/UserServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/UserServiceActiveTest.java
@@ -1,34 +1,43 @@
 package com.a2.backend.service.impl;
 
-import static org.junit.jupiter.api.Assertions.*;
-
+import com.a2.backend.constants.PrivacyConstant;
 import com.a2.backend.entity.Project;
+import com.a2.backend.entity.User;
+import com.a2.backend.exception.UserNotFoundException;
 import com.a2.backend.model.ProjectDTO;
 import com.a2.backend.model.ProjectSearchDTO;
+import com.a2.backend.model.UserPrivacyDTO;
+import com.a2.backend.model.UserProfileDTO;
 import com.a2.backend.service.ProjectService;
 import com.a2.backend.service.UserService;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
-public class UserServiceActiveTest extends AbstractServiceTest {
-    @Autowired private UserService userService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
-    @Autowired private ProjectService projectService;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UserServiceActiveTest extends AbstractServiceTest {
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private ProjectService projectService;
 
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
     void
-            Test001_GivenValidUserAndValidProjectsWhenWantToGetThePreferedProjectsThenReturnProjectList() {
-        List<String> preferedTags = new ArrayList<>();
-        preferedTags.add("Python");
-        preferedTags.add("C");
+    Test001_GivenValidUserAndValidProjectsWhenWantToGetThePreferredProjectsThenReturnProjectList() {
+        List<String> preferredTags = new ArrayList<>();
+        preferredTags.add("Python");
+        preferredTags.add("C");
 
-        userService.getLoggedUser().setPreferredTags(preferedTags);
-        ProjectSearchDTO projectSearchDTO = ProjectSearchDTO.builder().tags(preferedTags).build();
+        userService.getLoggedUser().setPreferredTags(preferredTags);
+        ProjectSearchDTO projectSearchDTO = ProjectSearchDTO.builder().tags(preferredTags).build();
         List<Project> preferredProjects = projectService.searchProjecsByFilter(projectSearchDTO);
         List<ProjectDTO> projects = userService.getPreferredProjects();
         assertEquals(6, projects.size());
@@ -48,7 +57,7 @@ public class UserServiceActiveTest extends AbstractServiceTest {
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
     void
-            Test002_GivenValidUserWithNotPreferedTagsWhenWantToGetProjectsThenReturnProjectListWithfourRandomProjectsAndTwoFeatured() {
+    Test002_GivenValidUserWithNotPreferredTagsWhenWantToGetProjectsThenReturnProjectListWithFourRandomProjectsAndTwoFeatured() {
 
         List<ProjectDTO> projects = userService.getPreferredProjects();
 
@@ -59,12 +68,12 @@ public class UserServiceActiveTest extends AbstractServiceTest {
 
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
-    void Test003_GivenNoFeaturedProjectsWhenWantPreferedProjectsThenFillWithNonFeaturedProjects() {
-        List<String> preferedTags = new ArrayList<>();
-        preferedTags.add("Python");
-        preferedTags.add("C");
-        userService.getLoggedUser().setPreferredTags(preferedTags);
-        ProjectSearchDTO projectSearchDTO = ProjectSearchDTO.builder().tags(preferedTags).build();
+    void Test003_GivenNoFeaturedProjectsWhenWantPreferredProjectsThenFillWithNonFeaturedProjects() {
+        List<String> preferredTags = new ArrayList<>();
+        preferredTags.add("Python");
+        preferredTags.add("C");
+        userService.getLoggedUser().setPreferredTags(preferredTags);
+        ProjectSearchDTO projectSearchDTO = ProjectSearchDTO.builder().tags(preferredTags).build();
         List<Project> preferredProjects = projectService.searchProjecsByFilter(projectSearchDTO);
         List<ProjectDTO> projects = userService.getPreferredProjects();
         for (int i = 0; i < projects.size(); i++) {
@@ -81,5 +90,60 @@ public class UserServiceActiveTest extends AbstractServiceTest {
         assertTrue(preferredProjectsId.contains(projects.get(3).getId()));
         assertTrue(preferredProjectsId.contains(projects.get(4).getId()));
         assertTrue(preferredProjectsId.contains(projects.get(5).getId()));
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void Test004_GivenValidUserWhenUpdatingPreferencesThenTheyAreUpdated() {
+        User loggedUser = userService.getLoggedUser();
+
+        assertEquals(PrivacyConstant.PUBLIC, loggedUser.getTagsPrivacy());
+        assertEquals(PrivacyConstant.PUBLIC, loggedUser.getLanguagesPrivacy());
+        assertEquals(PrivacyConstant.PUBLIC, loggedUser.getCollaboratedProjectsPrivacy());
+        assertEquals(PrivacyConstant.PUBLIC, loggedUser.getOwnedProjectsPrivacy());
+
+        UserPrivacyDTO privacyDTO =
+                UserPrivacyDTO.builder()
+                        .tagsPrivacy(PrivacyConstant.PRIVATE)
+                        .collaboratedProjectsPrivacy(PrivacyConstant.PRIVATE)
+                        .languagesPrivacy(PrivacyConstant.PRIVATE)
+                        .ownedProjectsPrivacy(PrivacyConstant.PRIVATE)
+                        .build();
+
+        User updatedUser = userService.updatePrivacySettings(privacyDTO);
+
+        assertEquals(PrivacyConstant.PRIVATE, updatedUser.getTagsPrivacy());
+        assertEquals(PrivacyConstant.PRIVATE, updatedUser.getLanguagesPrivacy());
+        assertEquals(PrivacyConstant.PRIVATE, updatedUser.getCollaboratedProjectsPrivacy());
+        assertEquals(PrivacyConstant.PRIVATE, updatedUser.getOwnedProjectsPrivacy());
+    }
+
+    @Test
+    @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
+    void Test005_GivenValidUserWhenGettingProfileThenOnlyFieldsWithPublicPrivacyAreReturned() {
+        User loggedUser = userService.getLoggedUser();
+        UserProfileDTO userProfile = userService.getUserProfile(loggedUser.getId());
+
+        assertEquals(loggedUser.getNickname(), userProfile.getNickname());
+        assertEquals(loggedUser.getBiography(), userProfile.getBiography());
+        assertEquals(loggedUser.getPreferredTags(), userProfile.getPreferredTags());
+        assertNotNull(userProfile.getOwnedProjects());
+        assertTrue(
+                projectService.getProjectsByOwner(loggedUser).stream()
+                        .map(Project::getId)
+                        .collect(Collectors.toList())
+                        .containsAll(
+                                userProfile.getOwnedProjects().stream()
+                                        .map(ProjectDTO::getId)
+                                        .collect(Collectors.toList())));
+        assertNull(userProfile.getCollaboratedProjects());
+        assertNull(userProfile.getPreferredLanguages());
+    }
+
+    @Test
+    @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
+    void Test006_GivenANonExistentUserIdWhenGettingProfileThenExceptionIsThrown() {
+        assertThrows(
+                UserNotFoundException.class, () -> userService.getUserProfile(UUID.randomUUID()));
     }
 }


### PR DESCRIPTION
US: Como usuario quiero poder ver perfiles de otros usuarios tal que pueda obtener más información de los mismos

La informacion a enviar es la siguiente:

- nick (publica siempre)
- bio (publica siempre)
- tags y lenguajes de preferencias (configurable por el usuario: default publica)
- projectos creados por ese usuario (configurable por el usuario: default publica)
- projectos en los que ese usario colabora (ver historia de postulacion y aceptacion) (configurable por el usuario: default publica)

Tener presente que cada usuario puede decidir que informacion quiere que sea publica, por lo que no solo tiene que haber un endpoint de get a /user/id
sino un endpoint que permita actualizar las preferencias acerca de si mostrar o no los: tags, lenguajes, proyectos de los que es dueño, proyectos de los que colabora y usarlos a la hora de mostrar la informacion cuando se llame al get /user/id
