### PR TITLE
Added feature administracion de postulantes

### DIFF
--- a/src/main/java/com/a2/backend/DemoRunner.java
+++ b/src/main/java/com/a2/backend/DemoRunner.java
@@ -123,8 +123,6 @@ public class DemoRunner implements CommandLineRunner {
                                         ForumTag.builder().name("GNU").build()))
                         .collaborators(List.of())
                         .applicants(List.of())
-                        .rejectedApplicants(
-                                List.of(userRepository.findByNickname("ropa1998").get()))
                         .build();
         Project tensorFlow =
                 Project.builder()
@@ -150,7 +148,6 @@ public class DemoRunner implements CommandLineRunner {
                                         ForumTag.builder().name("software library").build()))
                         .collaborators(List.of())
                         .applicants(List.of(userRepository.findByNickname("Peltevis").get()))
-                        .rejectedApplicants(List.of())
                         .build();
         Project node =
                 Project.builder()
@@ -178,7 +175,6 @@ public class DemoRunner implements CommandLineRunner {
                                         userRepository.findByNickname("ropa1998").get(),
                                         userRepository.findByNickname("Peltevis").get()))
                         .applicants(List.of())
-                        .rejectedApplicants(List.of())
                         .build();
 
         Project geany =
@@ -201,8 +197,6 @@ public class DemoRunner implements CommandLineRunner {
                         .forumTags(listOf(ForumTag.builder().name("lightweight IDE").build()))
                         .collaborators(List.of(userRepository.findByNickname("Peltevis").get()))
                         .applicants(List.of())
-                        .rejectedApplicants(
-                                List.of(userRepository.findByNickname("ropa1998").get()))
                         .build();
         Project django =
                 Project.builder()
@@ -223,7 +217,6 @@ public class DemoRunner implements CommandLineRunner {
                                         ForumTag.builder().name("high-level").build()))
                         .collaborators(List.of(userRepository.findByNickname("ropa1998").get()))
                         .applicants(List.of(userRepository.findByNickname("FabriDS23").get()))
-                        .rejectedApplicants(List.of())
                         .build();
         Project sakai =
                 Project.builder()
@@ -237,7 +230,6 @@ public class DemoRunner implements CommandLineRunner {
                         .forumTags(listOf(ForumTag.builder().name("help").build()))
                         .collaborators(List.of())
                         .applicants(List.of())
-                        .rejectedApplicants(List.of())
                         .build();
         Project apache =
                 Project.builder()
@@ -258,7 +250,6 @@ public class DemoRunner implements CommandLineRunner {
                         .featured(true)
                         .collaborators(List.of())
                         .applicants(List.of(userRepository.findByNickname("ropa1998").get()))
-                        .rejectedApplicants(List.of())
                         .build();
         Project renovate =
                 Project.builder()
@@ -279,8 +270,6 @@ public class DemoRunner implements CommandLineRunner {
                         .featured(true)
                         .collaborators(List.of())
                         .applicants(List.of())
-                        .rejectedApplicants(
-                                List.of(userRepository.findByNickname("FabriDS23").get()))
                         .build();
         Project kubernetes =
                 Project.builder()
@@ -299,8 +288,6 @@ public class DemoRunner implements CommandLineRunner {
                         .featured(true)
                         .collaborators(List.of())
                         .applicants(List.of())
-                        .rejectedApplicants(
-                                List.of(userRepository.findByNickname("Peltevis").get()))
                         .build();
         Project ansible =
                 Project.builder()
@@ -322,7 +309,6 @@ public class DemoRunner implements CommandLineRunner {
                         .featured(true)
                         .collaborators(List.of(userRepository.findByNickname("Peltevis").get()))
                         .applicants(List.of())
-                        .rejectedApplicants(List.of())
                         .build();
 
         projectRepository.save(linux);

--- a/src/main/java/com/a2/backend/controller/ProjectController.java
+++ b/src/main/java/com/a2/backend/controller/ProjectController.java
@@ -133,4 +133,27 @@ public class ProjectController {
         val createdDiscussion = discussionService.createDiscussion(id, discussionCreateDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdDiscussion);
     }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @GetMapping("/applicants/{id}")
+    public ResponseEntity<?> getProjectApplicants(@PathVariable UUID id) {
+        val projectApplicants = projectService.getProjectApplicants(id);
+        return ResponseEntity.status(HttpStatus.OK).body(projectApplicants);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @PutMapping("/accept/{projectId}/{userId}")
+    public ResponseEntity<?> acceptApplicant(
+            @PathVariable UUID projectId, @PathVariable UUID userId) {
+        val applicants = projectService.acceptApplicant(projectId, userId);
+        return ResponseEntity.status(HttpStatus.OK).body(applicants);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @PutMapping("/reject/{projectId}/{userId}")
+    public ResponseEntity<?> rejectApplicant(
+            @PathVariable UUID projectId, @PathVariable UUID userId) {
+        val applicants = projectService.rejectApplicant(projectId, userId);
+        return ResponseEntity.status(HttpStatus.OK).body(applicants);
+    }
 }

--- a/src/main/java/com/a2/backend/entity/Project.java
+++ b/src/main/java/com/a2/backend/entity/Project.java
@@ -73,11 +73,6 @@ public class Project implements Serializable {
     @NotNull
     private List<User> applicants;
 
-    @ManyToMany(cascade = CascadeType.MERGE)
-    @LazyCollection(LazyCollectionOption.FALSE)
-    @NotNull
-    private List<User> rejectedApplicants;
-
     public ProjectDTO toDTO() {
         return ProjectDTO.builder()
                 .id(id)
@@ -91,8 +86,6 @@ public class Project implements Serializable {
                 .owner(owner.toDTO())
                 .collaborators(collaborators.stream().map(User::toDTO).collect(Collectors.toList()))
                 .applicants(applicants.stream().map(User::toDTO).collect(Collectors.toList()))
-                .rejectedApplicants(
-                        rejectedApplicants.stream().map(User::toDTO).collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/com/a2/backend/exception/InvalidUserException.java
+++ b/src/main/java/com/a2/backend/exception/InvalidUserException.java
@@ -1,0 +1,7 @@
+package com.a2.backend.exception;
+
+public class InvalidUserException extends RuntimeException {
+    public InvalidUserException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
+++ b/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
@@ -116,7 +116,7 @@ public class DefaultExceptionHandler {
     }
 
     @ExceptionHandler(InvalidUserException.class)
-    protected ResponseEntity<?> handleNotTheProjectOwner(InvalidUserException exception) {
+    protected ResponseEntity<?> handleInvalidUser(InvalidUserException exception) {
         logger.info(exception.getMessage());
         return new ResponseEntity(exception.getMessage(), HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
+++ b/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
@@ -114,4 +114,10 @@ public class DefaultExceptionHandler {
         logger.info(exception.getMessage());
         return new ResponseEntity(exception.getMessage(), HttpStatus.UNAUTHORIZED);
     }
+
+    @ExceptionHandler(InvalidUserException.class)
+    protected ResponseEntity<?> handleNotTheProjectOwner(InvalidUserException exception) {
+        logger.info(exception.getMessage());
+        return new ResponseEntity(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/a2/backend/model/ProjectDTO.java
+++ b/src/main/java/com/a2/backend/model/ProjectDTO.java
@@ -33,6 +33,4 @@ public class ProjectDTO {
     private List<ProjectUserDTO> collaborators;
 
     private List<ProjectUserDTO> applicants;
-
-    private List<ProjectUserDTO> rejectedApplicants;
 }

--- a/src/main/java/com/a2/backend/service/ProjectService.java
+++ b/src/main/java/com/a2/backend/service/ProjectService.java
@@ -2,10 +2,7 @@ package com.a2.backend.service;
 
 import com.a2.backend.entity.Project;
 import com.a2.backend.entity.User;
-import com.a2.backend.model.ProjectCreateDTO;
-import com.a2.backend.model.ProjectDTO;
-import com.a2.backend.model.ProjectSearchDTO;
-import com.a2.backend.model.ProjectUpdateDTO;
+import com.a2.backend.model.*;
 import java.util.List;
 import java.util.UUID;
 
@@ -36,4 +33,10 @@ public interface ProjectService {
     List<Project> getProjectsByOwner(User owner);
 
     List<Project> getCollaboratingProjects(User user);
+
+    List<ProjectUserDTO> getProjectApplicants(UUID uuid);
+
+    List<ProjectUserDTO> acceptApplicant(UUID projectId, UUID userId);
+
+    List<ProjectUserDTO> rejectApplicant(UUID projectId, UUID userId);
 }

--- a/src/main/java/com/a2/backend/service/UserService.java
+++ b/src/main/java/com/a2/backend/service/UserService.java
@@ -31,4 +31,6 @@ public interface UserService {
     User updatePrivacySettings(UserPrivacyDTO userPrivacyDTO);
 
     UserProfileDTO getUserProfile(UUID id);
+
+    User getUser(UUID id);
 }

--- a/src/main/java/com/a2/backend/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/UserServiceImpl.java
@@ -292,4 +292,9 @@ public class UserServiceImpl implements UserService {
     public Optional<User> getUser() {
         return SecurityUtils.getCurrentUserLogin().flatMap(userRepository::findByEmail);
     }
+
+    @Override
+    public User getUser(UUID id) {
+        return userRepository.getById(id);
+    }
 }

--- a/src/test/java/com/a2/backend/repository/DiscussionRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/DiscussionRepositoryTest.java
@@ -52,7 +52,6 @@ public class DiscussionRepositoryTest {
                     .owner(owner)
                     .applicants(List.of())
                     .collaborators(List.of())
-                    .rejectedApplicants(List.of())
                     .build();
 
     Discussion discussion =

--- a/src/test/java/com/a2/backend/repository/ProjectRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/ProjectRepositoryTest.java
@@ -53,7 +53,6 @@ class ProjectRepositoryTest {
                     .owner(owner)
                     .applicants(List.of())
                     .collaborators(List.of())
-                    .rejectedApplicants(List.of())
                     .build();
 
     @Test
@@ -128,7 +127,6 @@ class ProjectRepositoryTest {
                         .owner(owner)
                         .applicants(List.of())
                         .collaborators(List.of())
-                        .rejectedApplicants(List.of())
                         .build());
         assertEquals(2, projectRepository.findAll().size());
 
@@ -159,7 +157,6 @@ class ProjectRepositoryTest {
                         .owner(owner2)
                         .applicants(List.of())
                         .collaborators(List.of())
-                        .rejectedApplicants(List.of())
                         .build());
         assertEquals(2, projectRepository.findAll().size());
 
@@ -187,7 +184,6 @@ class ProjectRepositoryTest {
                         .forumTags(forumTags)
                         .applicants(List.of())
                         .collaborators(List.of())
-                        .rejectedApplicants(List.of())
                         .build();
 
         Project project2 =
@@ -200,7 +196,6 @@ class ProjectRepositoryTest {
                         .forumTags(forumTags)
                         .applicants(List.of())
                         .collaborators(List.of())
-                        .rejectedApplicants(List.of())
                         .build();
 
         Project project3 =
@@ -213,7 +208,6 @@ class ProjectRepositoryTest {
                         .forumTags(forumTags)
                         .applicants(List.of())
                         .collaborators(List.of())
-                        .rejectedApplicants(List.of())
                         .build();
 
         projectRepository.save(project1);
@@ -252,7 +246,6 @@ class ProjectRepositoryTest {
                         .languages(Arrays.asList(language1, language2))
                         .applicants(List.of())
                         .collaborators(List.of())
-                        .rejectedApplicants(List.of())
                         .build();
 
         Project project2 =
@@ -266,7 +259,6 @@ class ProjectRepositoryTest {
                         .languages(Arrays.asList(language3, language2))
                         .applicants(List.of())
                         .collaborators(List.of())
-                        .rejectedApplicants(List.of())
                         .build();
 
         Project project3 =
@@ -280,7 +272,6 @@ class ProjectRepositoryTest {
                         .languages(Arrays.asList(language1, language3))
                         .applicants(List.of())
                         .collaborators(List.of())
-                        .rejectedApplicants(List.of())
                         .build();
 
         projectRepository.save(project1);
@@ -311,7 +302,6 @@ class ProjectRepositoryTest {
                         .forumTags(forumTags)
                         .applicants(List.of())
                         .collaborators(List.of())
-                        .rejectedApplicants(List.of())
                         .build();
         assertTrue(projectRepository.findAll().isEmpty());
         assertNull(project.getId());

--- a/src/test/java/com/a2/backend/service/impl/ProjectServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/ProjectServiceActiveTest.java
@@ -255,6 +255,7 @@ public class ProjectServiceActiveTest extends AbstractServiceTest {
 
         var applicant = userRepository.findByNickname("Peltevis");
 
+
         assertThrows(
                 InvalidUserException.class,
                 () -> projectService.rejectApplicant(project.getId(), applicant.get().getId()));


### PR DESCRIPTION
Como usuario owner del proyecto quiero poder aceptar o rechazar postulaciones tal que pueda sumar colaboradores al proyecto o rechazarlos

Si soy el dueño del proyecto en la vista de administración del proyecto se debe ver una tab para ver postulaciones. Los usuarios que no sean dueño no deben ver la página de administrador del proyecto
Si el usuario dueño hace click sobre alguno de los perfiles se lo debe redirigir a la página del perfil seleccionado
Debe haber un par de botones sobre los postulantes que le dejen elegir si los acepta o no
Una vez que se toma una decision la aplicacion debe desaparecer y se debe mostrar un mensaje que avise que la operación se realizo correctamente
Ante un error se debe mostrar un mensaje de error
Una vez aceptado al usuario postulante al revisar el proyecto se le debe mostrar que ya es colaborador. Si no fuera aceptado se volverá a habilitar el botón para postularse