### PR TITLE
Us 4.1.3/calificacion de colaboradores

### DIFF
--- a/src/main/java/com/a2/backend/DemoRunner.java
+++ b/src/main/java/com/a2/backend/DemoRunner.java
@@ -5,6 +5,7 @@ import com.a2.backend.constants.PrivacyConstant;
 import com.a2.backend.entity.*;
 import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.repository.UserRepository;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -121,6 +122,7 @@ public class DemoRunner implements CommandLineRunner {
                                         ForumTag.builder().name("GNU").build()))
                         .collaborators(List.of())
                         .applicants(List.of())
+                        .reviews(List.of())
                         .build();
         Project tensorFlow =
                 Project.builder()
@@ -145,6 +147,7 @@ public class DemoRunner implements CommandLineRunner {
                                         ForumTag.builder().name("software library").build()))
                         .collaborators(List.of())
                         .applicants(List.of(userRepository.findByNickname("Peltevis").get()))
+                        .reviews(List.of())
                         .build();
         Project node =
                 Project.builder()
@@ -172,6 +175,35 @@ public class DemoRunner implements CommandLineRunner {
                                         userRepository.findByNickname("ropa1998").get(),
                                         userRepository.findByNickname("Peltevis").get()))
                         .applicants(List.of())
+                        .reviews(
+                                List.of(
+                                        Review.builder()
+                                                .collaborator(
+                                                        userRepository
+                                                                .findByNickname("ropa1998")
+                                                                .get())
+                                                .score(5)
+                                                .date(LocalDateTime.now())
+                                                .comment("Did a great job")
+                                                .build(),
+                                        Review.builder()
+                                                .collaborator(
+                                                        userRepository
+                                                                .findByNickname("ropa1998")
+                                                                .get())
+                                                .score(3)
+                                                .date(LocalDateTime.now())
+                                                .comment(null)
+                                                .build(),
+                                        Review.builder()
+                                                .collaborator(
+                                                        userRepository
+                                                                .findByNickname("Peltevis")
+                                                                .get())
+                                                .score(4)
+                                                .date(LocalDateTime.now())
+                                                .comment(null)
+                                                .build()))
                         .build();
 
         Project geany =
@@ -194,6 +226,7 @@ public class DemoRunner implements CommandLineRunner {
                         .forumTags(listOf(ForumTag.builder().name("lightweight IDE").build()))
                         .collaborators(List.of(userRepository.findByNickname("Peltevis").get()))
                         .applicants(List.of())
+                        .reviews(List.of())
                         .build();
         Project django =
                 Project.builder()
@@ -214,6 +247,17 @@ public class DemoRunner implements CommandLineRunner {
                                         ForumTag.builder().name("high-level").build()))
                         .collaborators(List.of(userRepository.findByNickname("ropa1998").get()))
                         .applicants(List.of(userRepository.findByNickname("FabriDS23").get()))
+                        .reviews(
+                                List.of(
+                                        Review.builder()
+                                                .collaborator(
+                                                        userRepository
+                                                                .findByNickname("ropa1998")
+                                                                .get())
+                                                .score(2)
+                                                .date(LocalDateTime.now())
+                                                .comment(null)
+                                                .build()))
                         .build();
         Project sakai =
                 Project.builder()
@@ -227,6 +271,7 @@ public class DemoRunner implements CommandLineRunner {
                         .forumTags(listOf(ForumTag.builder().name("help").build()))
                         .collaborators(List.of())
                         .applicants(List.of())
+                        .reviews(List.of())
                         .build();
         Project apache =
                 Project.builder()
@@ -247,6 +292,7 @@ public class DemoRunner implements CommandLineRunner {
                         .featured(true)
                         .collaborators(List.of())
                         .applicants(List.of(userRepository.findByNickname("ropa1998").get()))
+                        .reviews(List.of())
                         .build();
         Project renovate =
                 Project.builder()
@@ -267,6 +313,7 @@ public class DemoRunner implements CommandLineRunner {
                         .featured(true)
                         .collaborators(List.of())
                         .applicants(List.of())
+                        .reviews(List.of())
                         .build();
         Project kubernetes =
                 Project.builder()
@@ -285,6 +332,7 @@ public class DemoRunner implements CommandLineRunner {
                         .featured(true)
                         .collaborators(List.of())
                         .applicants(List.of())
+                        .reviews(List.of())
                         .build();
         Project ansible =
                 Project.builder()
@@ -306,6 +354,7 @@ public class DemoRunner implements CommandLineRunner {
                         .featured(true)
                         .collaborators(List.of(userRepository.findByNickname("Peltevis").get()))
                         .applicants(List.of())
+                        .reviews(List.of())
                         .build();
 
         projectRepository.save(linux);

--- a/src/main/java/com/a2/backend/controller/ProjectController.java
+++ b/src/main/java/com/a2/backend/controller/ProjectController.java
@@ -3,10 +3,7 @@ package com.a2.backend.controller;
 import com.a2.backend.constants.SecurityConstants;
 import com.a2.backend.entity.ForumTag;
 import com.a2.backend.entity.Tag;
-import com.a2.backend.model.DiscussionCreateDTO;
-import com.a2.backend.model.ProjectCreateDTO;
-import com.a2.backend.model.ProjectSearchDTO;
-import com.a2.backend.model.ProjectUpdateDTO;
+import com.a2.backend.model.*;
 import com.a2.backend.service.DiscussionService;
 import com.a2.backend.service.ForumTagService;
 import com.a2.backend.service.ProjectService;
@@ -153,5 +150,21 @@ public class ProjectController {
             @PathVariable UUID projectId, @PathVariable UUID userId) {
         val applicants = projectService.rejectApplicant(projectId, userId);
         return ResponseEntity.status(HttpStatus.OK).body(applicants);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @PutMapping("/review/{id}")
+    public ResponseEntity<?> reviewCollaborator(
+            @Valid @RequestBody ReviewCreateDTO reviewCreateDTO, @PathVariable UUID id) {
+        val review = projectService.createReview(id, reviewCreateDTO);
+        return ResponseEntity.status(HttpStatus.OK).body(review);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @GetMapping("/reviews/{projectId}/{userId}")
+    public ResponseEntity<?> getUserReviewsInProject(
+            @PathVariable UUID projectId, @PathVariable UUID userId) {
+        val reviews = projectService.getUserReviews(projectId, userId);
+        return ResponseEntity.status(HttpStatus.OK).body(reviews);
     }
 }

--- a/src/main/java/com/a2/backend/entity/Project.java
+++ b/src/main/java/com/a2/backend/entity/Project.java
@@ -75,6 +75,11 @@ public class Project implements Serializable {
     @NotNull
     private List<User> applicants;
 
+    @OneToMany(cascade = CascadeType.ALL)
+    @LazyCollection(LazyCollectionOption.FALSE)
+    @NotNull
+    private List<Review> reviews;
+
     public ProjectDTO toDTO() {
         return ProjectDTO.builder()
                 .id(id)
@@ -88,6 +93,7 @@ public class Project implements Serializable {
                 .owner(owner.toDTO())
                 .collaborators(collaborators.stream().map(User::toDTO).collect(Collectors.toList()))
                 .applicants(applicants.stream().map(User::toDTO).collect(Collectors.toList()))
+                .reviews(reviews.stream().map(Review::toDTO).collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/com/a2/backend/entity/Review.java
+++ b/src/main/java/com/a2/backend/entity/Review.java
@@ -1,0 +1,41 @@
+package com.a2.backend.entity;
+
+import com.a2.backend.model.ReviewDTO;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import javax.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @ManyToOne(cascade = {CascadeType.MERGE})
+    private User collaborator;
+
+    private String comment;
+
+    private int score;
+
+    private LocalDateTime date;
+
+    public ReviewDTO toDTO() {
+        return ReviewDTO.builder()
+                .collaborator(collaborator.toDTO())
+                .comment(comment)
+                .score(score)
+                .date(date)
+                .id(id)
+                .build();
+    }
+}

--- a/src/main/java/com/a2/backend/entity/Review.java
+++ b/src/main/java/com/a2/backend/entity/Review.java
@@ -23,6 +23,7 @@ public class Review {
     @ManyToOne(cascade = {CascadeType.MERGE})
     private User collaborator;
 
+    @Column(length = 500)
     private String comment;
 
     private int score;

--- a/src/main/java/com/a2/backend/exception/NotValidCollaboratorException.java
+++ b/src/main/java/com/a2/backend/exception/NotValidCollaboratorException.java
@@ -1,0 +1,7 @@
+package com.a2.backend.exception;
+
+public class NotValidCollaboratorException extends RuntimeException {
+    public NotValidCollaboratorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
+++ b/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
@@ -120,4 +120,11 @@ public class DefaultExceptionHandler {
         logger.info(exception.getMessage());
         return new ResponseEntity(exception.getMessage(), HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(NotValidCollaboratorException.class)
+    protected ResponseEntity<?> handleNotValidCollaborator(
+            NotValidCollaboratorException exception) {
+        logger.info(exception.getMessage());
+        return new ResponseEntity(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/a2/backend/model/ProjectDTO.java
+++ b/src/main/java/com/a2/backend/model/ProjectDTO.java
@@ -36,4 +36,6 @@ public class ProjectDTO {
     private List<ProjectUserDTO> collaborators;
 
     private List<ProjectUserDTO> applicants;
+
+    private List<ReviewDTO> reviews;
 }

--- a/src/main/java/com/a2/backend/model/ReviewCreateDTO.java
+++ b/src/main/java/com/a2/backend/model/ReviewCreateDTO.java
@@ -1,0 +1,27 @@
+package com.a2.backend.model;
+
+import com.sun.istack.NotNull;
+import java.util.UUID;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewCreateDTO {
+
+    @NotNull private UUID collaboratorID;
+
+    @Size(min = 10, max = 500, message = "Comment should be between 10 and 500 characters")
+    private String comment;
+
+    @NotNull
+    @Max(value = 5, message = "Max score is 5")
+    @Min(value = 1, message = "Min score is 1")
+    private int score;
+}

--- a/src/main/java/com/a2/backend/model/ReviewDTO.java
+++ b/src/main/java/com/a2/backend/model/ReviewDTO.java
@@ -1,0 +1,24 @@
+package com.a2.backend.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewDTO {
+
+    private UUID id;
+
+    private ProjectUserDTO collaborator;
+
+    private String comment;
+
+    private int score;
+
+    private LocalDateTime date;
+}

--- a/src/main/java/com/a2/backend/repository/ReviewRepository.java
+++ b/src/main/java/com/a2/backend/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.a2.backend.repository;
+
+import com.a2.backend.entity.Review;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, UUID> {}

--- a/src/main/java/com/a2/backend/service/ProjectService.java
+++ b/src/main/java/com/a2/backend/service/ProjectService.java
@@ -39,4 +39,8 @@ public interface ProjectService {
     List<ProjectUserDTO> acceptApplicant(UUID projectId, UUID userId);
 
     List<ProjectUserDTO> rejectApplicant(UUID projectId, UUID userId);
+
+    ReviewDTO createReview(UUID id, ReviewCreateDTO reviewCreateDTO);
+
+    List<ReviewDTO> getUserReviews(UUID projectId, UUID userId);
 }

--- a/src/main/java/com/a2/backend/service/ReviewService.java
+++ b/src/main/java/com/a2/backend/service/ReviewService.java
@@ -1,0 +1,9 @@
+package com.a2.backend.service;
+
+import com.a2.backend.entity.Review;
+import com.a2.backend.model.ReviewCreateDTO;
+
+public interface ReviewService {
+
+    Review createReview(ReviewCreateDTO reviewCreateDTO);
+}

--- a/src/main/java/com/a2/backend/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/ReviewServiceImpl.java
@@ -1,0 +1,44 @@
+package com.a2.backend.service.impl;
+
+import com.a2.backend.entity.Review;
+import com.a2.backend.exception.InvalidUserException;
+import com.a2.backend.model.ReviewCreateDTO;
+import com.a2.backend.repository.ReviewRepository;
+import com.a2.backend.repository.UserRepository;
+import com.a2.backend.service.ReviewService;
+import java.time.LocalDateTime;
+import lombok.val;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReviewServiceImpl implements ReviewService {
+
+    private final UserRepository userRepository;
+
+    private final ReviewRepository reviewRepository;
+
+    public ReviewServiceImpl(UserRepository userRepository, ReviewRepository reviewRepository) {
+        this.userRepository = userRepository;
+        this.reviewRepository = reviewRepository;
+    }
+
+    @Override
+    public Review createReview(ReviewCreateDTO reviewCreateDTO) {
+        val collaborator = userRepository.findById(reviewCreateDTO.getCollaboratorID());
+        if (collaborator.isEmpty()) {
+            throw new InvalidUserException(
+                    String.format(
+                            "User with id %s not found", reviewCreateDTO.getCollaboratorID()));
+        }
+
+        Review review =
+                Review.builder()
+                        .collaborator(collaborator.get())
+                        .comment(reviewCreateDTO.getComment())
+                        .score(reviewCreateDTO.getScore())
+                        .date(LocalDateTime.now())
+                        .build();
+
+        return review;
+    }
+}

--- a/src/test/java/com/a2/backend/repository/DiscussionRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/DiscussionRepositoryTest.java
@@ -52,6 +52,7 @@ public class DiscussionRepositoryTest {
                     .owner(owner)
                     .applicants(List.of())
                     .collaborators(List.of())
+                    .reviews(List.of())
                     .build();
 
     Discussion discussion =

--- a/src/test/java/com/a2/backend/repository/ProjectRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/ProjectRepositoryTest.java
@@ -53,6 +53,7 @@ class ProjectRepositoryTest {
                     .owner(owner)
                     .applicants(List.of())
                     .collaborators(List.of())
+                    .reviews(List.of())
                     .build();
 
     @Test
@@ -127,6 +128,7 @@ class ProjectRepositoryTest {
                         .owner(owner)
                         .applicants(List.of())
                         .collaborators(List.of())
+                        .reviews(List.of())
                         .build());
         assertEquals(2, projectRepository.findAll().size());
 
@@ -157,6 +159,7 @@ class ProjectRepositoryTest {
                         .owner(owner2)
                         .applicants(List.of())
                         .collaborators(List.of())
+                        .reviews(List.of())
                         .build());
         assertEquals(2, projectRepository.findAll().size());
 
@@ -184,6 +187,7 @@ class ProjectRepositoryTest {
                         .forumTags(forumTags)
                         .applicants(List.of())
                         .collaborators(List.of())
+                        .reviews(List.of())
                         .build();
 
         Project project2 =
@@ -196,6 +200,7 @@ class ProjectRepositoryTest {
                         .forumTags(forumTags)
                         .applicants(List.of())
                         .collaborators(List.of())
+                        .reviews(List.of())
                         .build();
 
         Project project3 =
@@ -208,6 +213,7 @@ class ProjectRepositoryTest {
                         .forumTags(forumTags)
                         .applicants(List.of())
                         .collaborators(List.of())
+                        .reviews(List.of())
                         .build();
 
         projectRepository.save(project1);
@@ -246,6 +252,7 @@ class ProjectRepositoryTest {
                         .languages(Arrays.asList(language1, language2))
                         .applicants(List.of())
                         .collaborators(List.of())
+                        .reviews(List.of())
                         .build();
 
         Project project2 =
@@ -259,6 +266,7 @@ class ProjectRepositoryTest {
                         .languages(Arrays.asList(language3, language2))
                         .applicants(List.of())
                         .collaborators(List.of())
+                        .reviews(List.of())
                         .build();
 
         Project project3 =
@@ -272,6 +280,7 @@ class ProjectRepositoryTest {
                         .languages(Arrays.asList(language1, language3))
                         .applicants(List.of())
                         .collaborators(List.of())
+                        .reviews(List.of())
                         .build();
 
         projectRepository.save(project1);
@@ -302,6 +311,7 @@ class ProjectRepositoryTest {
                         .forumTags(forumTags)
                         .applicants(List.of())
                         .collaborators(List.of())
+                        .reviews(List.of())
                         .build();
         assertTrue(projectRepository.findAll().isEmpty());
         assertNull(project.getId());

--- a/src/test/java/com/a2/backend/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/ReviewRepositoryTest.java
@@ -1,0 +1,96 @@
+package com.a2.backend.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.a2.backend.BackendApplication;
+import com.a2.backend.entity.Review;
+import com.a2.backend.entity.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@AutoConfigureWebClient
+@DataJpaTest
+@ExtendWith(SpringExtension.class)
+@Import({BackendApplication.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+public class ReviewRepositoryTest {
+
+    @Autowired ReviewRepository reviewRepository;
+
+    @Autowired UserRepository userRepository;
+
+    User user =
+            User.builder()
+                    .nickname("nickname")
+                    .email("some@email.com")
+                    .biography("bio")
+                    .password("hashed_password")
+                    .build();
+
+    User user2 =
+            User.builder()
+                    .nickname("nickname2")
+                    .email("some2@email.com")
+                    .biography("bio2")
+                    .password("hashed_password")
+                    .build();
+
+    Review review =
+            Review.builder()
+                    .collaborator(user)
+                    .score(4)
+                    .comment("Insert valid comment")
+                    .date(LocalDateTime.now())
+                    .build();
+
+    Review review2 =
+            Review.builder()
+                    .collaborator(user)
+                    .score(2)
+                    .comment(null)
+                    .date(LocalDateTime.now())
+                    .build();
+
+    Review review3 =
+            Review.builder()
+                    .collaborator(user2)
+                    .score(5)
+                    .comment("Excellent job")
+                    .date(LocalDateTime.now())
+                    .build();
+
+    @Test
+    void Test001_ReviewRepositoryShouldSaveReviews() {
+        userRepository.save(user);
+
+        assertTrue(reviewRepository.findAll().isEmpty());
+
+        assertNull(review.getId());
+
+        reviewRepository.save(review);
+
+        assertFalse(reviewRepository.findAll().isEmpty());
+
+        List<Review> reviews = reviewRepository.findAll();
+
+        assertEquals(1, reviews.size());
+
+        System.out.println(review.getDate());
+
+        val savedReview = reviews.get(0);
+
+        assertNotNull(savedReview.getId());
+        assertEquals("nickname", savedReview.getCollaborator().getNickname());
+    }
+}

--- a/src/test/java/com/a2/backend/service/impl/ProjectServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/ProjectServiceActiveTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.a2.backend.entity.User;
 import com.a2.backend.exception.InvalidProjectCollaborationApplicationException;
 import com.a2.backend.exception.InvalidUserException;
+import com.a2.backend.exception.NotValidCollaboratorException;
 import com.a2.backend.exception.ProjectNotFoundException;
 import com.a2.backend.model.ProjectDTO;
 import com.a2.backend.model.ProjectSearchDTO;
@@ -327,7 +328,7 @@ public class ProjectServiceActiveTest extends AbstractServiceTest {
     void Test019_ProjectServiceWhenNotProjectOwnerSubmitsReviewShouldThrowException() {
 
         ProjectSearchDTO projectSearchDTO = ProjectSearchDTO.builder().title("Geany").build();
-        Project project = projectService.searchProjectsByFilter(projectSearchDTO).get(0);
+        val project = projectService.searchProjectsByFilter(projectSearchDTO).get(0);
 
         val collaborator = userRepository.findByNickname("Peltevis");
 
@@ -367,7 +368,7 @@ public class ProjectServiceActiveTest extends AbstractServiceTest {
             Test021_ProjectServiceWithNotValidCollaboratorIdWhenSubmittingReviewShouldThrowException() {
 
         ProjectSearchDTO projectSearchDTO = ProjectSearchDTO.builder().title("Geany").build();
-        Project project = projectService.searchProjectsByFilter(projectSearchDTO).get(0);
+        val project = projectService.searchProjectsByFilter(projectSearchDTO).get(0);
 
         val collaborator = userRepository.findByNickname("ropa1998");
 
@@ -379,7 +380,7 @@ public class ProjectServiceActiveTest extends AbstractServiceTest {
                         .build();
 
         assertThrows(
-                ProjectNotFoundException.class,
+                NotValidCollaboratorException.class,
                 () -> projectService.createReview(project.getId(), reviewCreateDTO));
     }
 
@@ -389,7 +390,7 @@ public class ProjectServiceActiveTest extends AbstractServiceTest {
             Test022_ProjectServiceWithValidReviewCreateDTOWhenSubmittingReviewShouldUpdateReviewList() {
 
         ProjectSearchDTO projectSearchDTO = ProjectSearchDTO.builder().title("Geany").build();
-        Project project = projectService.searchProjectsByFilter(projectSearchDTO).get(0);
+        val project = projectService.searchProjectsByFilter(projectSearchDTO).get(0);
 
         val collaborator = userRepository.findByNickname("Peltevis");
 
@@ -403,7 +404,9 @@ public class ProjectServiceActiveTest extends AbstractServiceTest {
         assertEquals(0, project.getReviews().size());
         val review = projectService.createReview(project.getId(), reviewCreateDTO);
 
-        assertEquals(1, project.getReviews().size());
+        val projectUpdated = projectService.searchProjectsByFilter(projectSearchDTO).get(0);
+
+        assertEquals(1, projectUpdated.getReviews().size());
 
         assertEquals(review.getCollaborator().getId(), reviewCreateDTO.getCollaboratorID());
         assertEquals(review.getScore(), reviewCreateDTO.getScore());
@@ -415,7 +418,7 @@ public class ProjectServiceActiveTest extends AbstractServiceTest {
     void Test022_ProjectServiceWithValidProjectIdAndUserIdShouldReturnUserReviewsInGivenProject() {
 
         ProjectSearchDTO projectSearchDTO = ProjectSearchDTO.builder().title("Node.js").build();
-        Project project = projectService.searchProjectsByFilter(projectSearchDTO).get(0);
+        val project = projectService.searchProjectsByFilter(projectSearchDTO).get(0);
 
         val collaborator = userRepository.findByNickname("ropa1998");
 
@@ -444,7 +447,7 @@ public class ProjectServiceActiveTest extends AbstractServiceTest {
             Test024_ProjectServiceWhenNotProjectOwnerAsksForCollaboratorsReviewsShouldThrowException() {
 
         ProjectSearchDTO projectSearchDTO = ProjectSearchDTO.builder().title("Node.js").build();
-        Project project = projectService.searchProjectsByFilter(projectSearchDTO).get(0);
+        val project = projectService.searchProjectsByFilter(projectSearchDTO).get(0);
 
         val collaborator = userRepository.findByNickname("ropa1998");
 

--- a/src/test/java/com/a2/backend/service/impl/ReviewServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/ReviewServiceActiveTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
-class ReviewServiceImplTest extends AbstractServiceTest {
+class ReviewServiceActiveTest extends AbstractServiceTest {
 
     @Autowired private UserRepository userRepository;
 

--- a/src/test/java/com/a2/backend/service/impl/ReviewServiceImplTest.java
+++ b/src/test/java/com/a2/backend/service/impl/ReviewServiceImplTest.java
@@ -1,0 +1,55 @@
+package com.a2.backend.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.a2.backend.exception.InvalidUserException;
+import com.a2.backend.model.ReviewCreateDTO;
+import com.a2.backend.repository.UserRepository;
+import com.a2.backend.service.ReviewService;
+import java.util.UUID;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+
+class ReviewServiceImplTest extends AbstractServiceTest {
+
+    @Autowired private UserRepository userRepository;
+
+    @Autowired private ReviewService reviewService;
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void Test001_ReviewServiceWhenReceivesNotValidCollaboratorIdShouldThrowException() {
+
+        ReviewCreateDTO reviewCreateDTO =
+                ReviewCreateDTO.builder()
+                        .collaboratorID(UUID.randomUUID())
+                        .score(5)
+                        .comment(null)
+                        .build();
+
+        assertThrows(InvalidUserException.class, () -> reviewService.createReview(reviewCreateDTO));
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void Test002_ReviewServiceWhenReceivesValidReviewCreateCTOShouldCreateReview() {
+        val collaborator = userRepository.findByNickname("Peltevis");
+
+        ReviewCreateDTO reviewCreateDTO =
+                ReviewCreateDTO.builder()
+                        .collaboratorID(collaborator.get().getId())
+                        .score(5)
+                        .comment(null)
+                        .build();
+
+        val createdReview = reviewService.createReview(reviewCreateDTO);
+
+        assertNotNull(createdReview);
+
+        assertEquals(createdReview.getCollaborator().getId(), reviewCreateDTO.getCollaboratorID());
+        assertEquals(createdReview.getScore(), reviewCreateDTO.getScore());
+        assertEquals(createdReview.getComment(), reviewCreateDTO.getComment());
+    }
+}


### PR DESCRIPTION
Como usuario dueño de proyecto quiero poder calificar a los colaboradores del proyecto tal que se actualice su valor de reputación

Desde la vista de administración de proyecto en la tab de colaboradores del proyecto se debe poder calificar a cada uno de los colaboradores
Cuando se lo va a calificar se completa un pop up que tiene un puntaje del 1 al 5. La calificación mínima es un 1.
El comentario debe ser opcional y debe tener un máximo de 500 caracteres
Una vez que la calificación se realizó se debe mostrar un mensaje que diga que fue realizada exitosamente
Si falla debe aparecer un mensaje
Se debe poder ver el historial de calificaciones realizadas para cada usuario. Esto debe verse como un pop up de la pantalla de colaboradores del proyecto (Para cada proyecto, poder pedir una lista que contenga los datos: user, fecha, comentario y califacion). Esto solo lo puede ver el owner de un proyecto.
Cada calificación tiene una fecha en la que fue realizada, el puntaje asignado y el comentario si este existe para esa calificación en particular