### PR TITLE
Us 5.3.3/resaltar esconder comentarios

### DIFF
--- a/src/main/java/com/a2/backend/DemoRunner.java
+++ b/src/main/java/com/a2/backend/DemoRunner.java
@@ -384,6 +384,32 @@ public class DemoRunner implements CommandLineRunner {
                                                                 "A ViewSet class is simply a type of class-based View, that does not provide any method handlers such as .get() or .post(), and instead provides actions such as .list() and .create().")
                                                         .user(peltevis)
                                                         .date(LocalDateTime.now())
+                                                        .highlighted(false)
+                                                        .hidden(false)
+                                                        .build(),
+                                                Comment.builder()
+                                                        .comment(
+                                                                "The method handlers for a ViewSet are only bound to the corresponding actions at the point of finalizing the view, using the .as_view() method.")
+                                                        .user(peltevis)
+                                                        .date(LocalDateTime.now().plusNanos(1))
+                                                        .highlighted(true)
+                                                        .hidden(false)
+                                                        .build(),
+                                                Comment.builder()
+                                                        .comment(
+                                                                "An advantage of using a ViewSet class over using a View class is that repeated logic can be combined into a single class.")
+                                                        .user(peltevis)
+                                                        .date(LocalDateTime.now().plusNanos(2))
+                                                        .highlighted(false)
+                                                        .hidden(true)
+                                                        .build(),
+                                                Comment.builder()
+                                                        .comment(
+                                                                "The ViewSet class inherits from APIView. You can use any of the standard attributes such as permission_classes, authentication_classes in order to control the API policy on the viewset.")
+                                                        .user(peltevis)
+                                                        .date(LocalDateTime.now().plusNanos(3))
+                                                        .highlighted(true)
+                                                        .hidden(false)
                                                         .build()))
                                 .build()));
         kubernetes.setDiscussions(
@@ -398,11 +424,15 @@ public class DemoRunner implements CommandLineRunner {
                                                         .comment("You should try a reinstall")
                                                         .user(franz)
                                                         .date(LocalDateTime.now())
+                                                        .highlighted(false)
+                                                        .hidden(false)
                                                         .build(),
                                                 Comment.builder()
                                                         .comment("Or maybe just a reboot first...")
                                                         .user(ropa1998)
                                                         .date(LocalDateTime.now().plusNanos(1))
+                                                        .highlighted(false)
+                                                        .hidden(true)
                                                         .build()))
                                 .build(),
                         Discussion.builder()

--- a/src/main/java/com/a2/backend/controller/ProjectController.java
+++ b/src/main/java/com/a2/backend/controller/ProjectController.java
@@ -192,16 +192,9 @@ public class ProjectController {
     }
 
     @Secured({SecurityConstants.USER_ROLE})
-    @GetMapping("/all-comments/{discussionId}")
+    @GetMapping("/comments/{discussionId}")
     public ResponseEntity<?> getCommentsInDiscussion(@PathVariable UUID discussionId) {
         val comments = discussionService.getComments(discussionId);
-        return ResponseEntity.status(HttpStatus.OK).body(comments);
-    }
-
-    @Secured({SecurityConstants.USER_ROLE})
-    @GetMapping("/filtered-comments/{discussionId}")
-    public ResponseEntity<?> getFilteredCommentsInDiscussion(@PathVariable UUID discussionId) {
-        val comments = discussionService.getFilteredComments(discussionId);
         return ResponseEntity.status(HttpStatus.OK).body(comments);
     }
 }

--- a/src/main/java/com/a2/backend/controller/ProjectController.java
+++ b/src/main/java/com/a2/backend/controller/ProjectController.java
@@ -176,4 +176,32 @@ public class ProjectController {
         val comment = discussionService.createComment(discussionId, commentCreateDTO);
         return ResponseEntity.status(HttpStatus.OK).body(comment);
     }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @PutMapping("/highlight/{commentId}")
+    public ResponseEntity<?> highlightComment(@PathVariable UUID commentId) {
+        val comment = discussionService.changeCommentHighlight(commentId);
+        return ResponseEntity.status(HttpStatus.OK).body(comment);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @PutMapping("/hide/{commentId}")
+    public ResponseEntity<?> hideComment(@PathVariable UUID commentId) {
+        val comment = discussionService.changeCommentHidden(commentId);
+        return ResponseEntity.status(HttpStatus.OK).body(comment);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @GetMapping("/all-comments/{discussionId}")
+    public ResponseEntity<?> getCommentsInDiscussion(@PathVariable UUID discussionId) {
+        val comments = discussionService.getComments(discussionId);
+        return ResponseEntity.status(HttpStatus.OK).body(comments);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @GetMapping("/filtered-comments/{discussionId}")
+    public ResponseEntity<?> getFilteredCommentsInDiscussion(@PathVariable UUID discussionId) {
+        val comments = discussionService.getFilteredComments(discussionId);
+        return ResponseEntity.status(HttpStatus.OK).body(comments);
+    }
 }

--- a/src/main/java/com/a2/backend/entity/Comment.java
+++ b/src/main/java/com/a2/backend/entity/Comment.java
@@ -28,7 +28,18 @@ public class Comment {
 
     private LocalDateTime date;
 
+    private boolean hidden;
+
+    private boolean highlighted;
+
     public CommentDTO toDTO() {
-        return CommentDTO.builder().id(id).user(user.toDTO()).comment(comment).date(date).build();
+        return CommentDTO.builder()
+                .id(id)
+                .user(user.toDTO())
+                .comment(comment)
+                .date(date)
+                .hidden(hidden)
+                .highlighted(highlighted)
+                .build();
     }
 }

--- a/src/main/java/com/a2/backend/entity/Discussion.java
+++ b/src/main/java/com/a2/backend/entity/Discussion.java
@@ -1,9 +1,9 @@
 package com.a2.backend.entity;
 
-import com.a2.backend.model.DiscussionDTO;
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import java.util.List;
 import java.util.UUID;
+import com.a2.backend.model.DiscussionDTO;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;

--- a/src/main/java/com/a2/backend/entity/Discussion.java
+++ b/src/main/java/com/a2/backend/entity/Discussion.java
@@ -1,9 +1,9 @@
 package com.a2.backend.entity;
 
-import java.util.List;
-import java.util.UUID;
 import com.a2.backend.model.DiscussionDTO;
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import java.util.List;
+import java.util.UUID;
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;

--- a/src/main/java/com/a2/backend/exception/CommentNotFoundException.java
+++ b/src/main/java/com/a2/backend/exception/CommentNotFoundException.java
@@ -1,0 +1,7 @@
+package com.a2.backend.exception;
+
+public class CommentNotFoundException extends RuntimeException {
+    public CommentNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
+++ b/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
@@ -139,4 +139,10 @@ public class DefaultExceptionHandler {
         logger.info(exception.getMessage());
         return new ResponseEntity(exception.getMessage(), HttpStatus.UNAUTHORIZED);
     }
+
+    @ExceptionHandler(CommentNotFoundException.class)
+    protected ResponseEntity<?> handleCommentNotFound(CommentNotFoundException exception) {
+        logger.info(exception.getMessage());
+        return new ResponseEntity(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/a2/backend/model/CommentDTO.java
+++ b/src/main/java/com/a2/backend/model/CommentDTO.java
@@ -19,4 +19,8 @@ public class CommentDTO {
     private String comment;
 
     private LocalDateTime date;
+
+    private boolean hidden;
+
+    private boolean highlighted;
 }

--- a/src/main/java/com/a2/backend/model/ReviewCreateDTO.java
+++ b/src/main/java/com/a2/backend/model/ReviewCreateDTO.java
@@ -17,7 +17,7 @@ public class ReviewCreateDTO {
 
     @NotNull private UUID collaboratorID;
 
-    @Size(min = 10, max = 500, message = "Comment should be between 10 and 500 characters")
+    @Size(max = 500, message = "Comment should be between 10 and 500 characters")
     private String comment;
 
     @NotNull

--- a/src/main/java/com/a2/backend/repository/DiscussionRepository.java
+++ b/src/main/java/com/a2/backend/repository/DiscussionRepository.java
@@ -10,5 +10,8 @@ public interface DiscussionRepository extends JpaRepository<Discussion, UUID> {
     @Query("SELECT d FROM Discussion d WHERE d.title LIKE ?2 AND d.project.id=?1")
     Discussion findByProjectIdAndTitle(UUID id, String title);
 
+    @Query("SELECT DISTINCT d FROM Discussion d JOIN d.comments c WHERE UPPER(c.id) = ?1 ")
+    Optional<Discussion> findDiscussionByCommentId(UUID commentId);
+
     Optional<Discussion> findByTitle(String title);
 }

--- a/src/main/java/com/a2/backend/service/CommentService.java
+++ b/src/main/java/com/a2/backend/service/CommentService.java
@@ -2,8 +2,13 @@ package com.a2.backend.service;
 
 import com.a2.backend.entity.Comment;
 import com.a2.backend.model.CommentCreateDTO;
+import java.util.UUID;
 
 public interface CommentService {
 
     Comment createComment(CommentCreateDTO commentCreateDTO);
+
+    Comment changeHighlight(UUID commentId);
+
+    Comment changeHidden(UUID commentId);
 }

--- a/src/main/java/com/a2/backend/service/DiscussionService.java
+++ b/src/main/java/com/a2/backend/service/DiscussionService.java
@@ -26,6 +26,4 @@ public interface DiscussionService {
     CommentDTO changeCommentHidden(UUID commentId);
 
     List<CommentDTO> getComments(UUID discussionId);
-
-    List<CommentDTO> getFilteredComments(UUID discussionId);
 }

--- a/src/main/java/com/a2/backend/service/DiscussionService.java
+++ b/src/main/java/com/a2/backend/service/DiscussionService.java
@@ -5,6 +5,7 @@ import com.a2.backend.model.CommentDTO;
 import com.a2.backend.model.DiscussionCreateDTO;
 import com.a2.backend.model.DiscussionDTO;
 import com.a2.backend.model.DiscussionUpdateDTO;
+import java.util.List;
 import java.util.UUID;
 
 public interface DiscussionService {
@@ -19,4 +20,12 @@ public interface DiscussionService {
     public DiscussionDTO getDiscussionDetails(UUID discussionID);
 
     void deleteDiscussion(UUID discussionID);
+
+    CommentDTO changeCommentHighlight(UUID commentId);
+
+    CommentDTO changeCommentHidden(UUID commentId);
+
+    List<CommentDTO> getComments(UUID discussionId);
+
+    List<CommentDTO> getFilteredComments(UUID discussionId);
 }

--- a/src/main/java/com/a2/backend/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/CommentServiceImpl.java
@@ -1,18 +1,25 @@
 package com.a2.backend.service.impl;
 
 import com.a2.backend.entity.Comment;
+import com.a2.backend.exception.CommentNotFoundException;
 import com.a2.backend.model.CommentCreateDTO;
+import com.a2.backend.repository.CommentRepository;
 import com.a2.backend.service.CommentService;
 import com.a2.backend.service.UserService;
 import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.val;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CommentServiceImpl implements CommentService {
     private final UserService userService;
 
-    public CommentServiceImpl(UserService userService) {
+    private final CommentRepository commentRepository;
+
+    public CommentServiceImpl(UserService userService, CommentRepository commentRepository) {
         this.userService = userService;
+        this.commentRepository = commentRepository;
     }
 
     @Override
@@ -21,6 +28,48 @@ public class CommentServiceImpl implements CommentService {
                 .user(userService.getLoggedUser())
                 .comment(commentCreateDTO.getComment())
                 .date(LocalDateTime.now())
+                .hidden(false)
+                .highlighted(false)
                 .build();
+    }
+
+    @Override
+    public Comment changeHighlight(UUID commentId) {
+        val commentOptional = commentRepository.findById(commentId);
+
+        if (commentOptional.isEmpty()) {
+            throw new CommentNotFoundException(
+                    String.format("Comment with id: %s not found", commentId));
+        }
+
+        val comment = commentOptional.get();
+
+        comment.setHighlighted(!comment.isHighlighted());
+
+        if (comment.isHighlighted() && comment.isHidden()) {
+            comment.setHidden(!comment.isHidden());
+        }
+
+        return comment;
+    }
+
+    @Override
+    public Comment changeHidden(UUID commentId) {
+        val commentOptional = commentRepository.findById(commentId);
+
+        if (commentOptional.isEmpty()) {
+            throw new CommentNotFoundException(
+                    String.format("Comment with id: %s not found", commentId));
+        }
+
+        val comment = commentOptional.get();
+
+        comment.setHidden(!comment.isHidden());
+
+        if (comment.isHidden() && comment.isHighlighted()) {
+            comment.setHighlighted(!comment.isHighlighted());
+        }
+
+        return comment;
     }
 }

--- a/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
@@ -24,7 +24,6 @@ import javax.transaction.Transactional;
 import lombok.val;
 import org.springframework.stereotype.Service;
 
-
 @Service
 public class DiscussionServiceImpl implements DiscussionService {
 

--- a/src/test/java/com/a2/backend/controller/ProjectControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/ProjectControllerActiveTest.java
@@ -940,7 +940,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
 
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
-    void Test0038_ProjectControllerWhenReceivesValidUpdateDiscussionDTOshouldReturnOK()
+    void Test0035_ProjectControllerWhenReceivesValidUpdateDiscussionDTOshouldReturnOK()
             throws Exception {
 
         val project = projectRepository.findByTitle("Renovate");
@@ -1016,7 +1016,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
     void
-            Test0039_ProjectControllerWhenReceivesValidUpdateDiscussionDTOButNotFromOwnerShouldReturnUnauthorized()
+            Test0036_ProjectControllerWhenReceivesValidUpdateDiscussionDTOButNotFromOwnerShouldReturnUnauthorized()
                     throws Exception {
         List<String> discussionTags = Arrays.asList("desctag1", "desctag2");
         DiscussionUpdateDTO discussionUpdateDTO =
@@ -1048,7 +1048,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
     void
-            Test0040_ProjectControllerWhenReceivesValidUpdateDiscussionDTOButNotFromOwnerShouldReturnUnauthorized()
+            Test0037_ProjectControllerWhenReceivesValidUpdateDiscussionDTOButNotFromOwnerShouldReturnUnauthorized()
                     throws Exception {
         List<String> discussionTags = Arrays.asList("desctag1", "desctag2");
         DiscussionUpdateDTO discussionUpdateDTO =

--- a/src/test/java/com/a2/backend/controller/ProjectControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/ProjectControllerActiveTest.java
@@ -871,39 +871,16 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
                 .contains("Only project owners can hide comments"));
     }
 
-    ////
-    @Test
-    @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void
-            Test032_ProjectControllerWithValidDiscussionIdButNotOwnerWhenGettingAllCommentsShouldReturnBadRequest()
-                    throws Exception {
-
-        val discussion = projectRepository.findByTitle("Kubernetes").get().getDiscussions().get(0);
-
-        String errorMessage =
-                mvc.perform(
-                                MockMvcRequestBuilders.get(
-                                                baseUrl + "/all-comments/" + discussion.getId())
-                                        .accept(MediaType.APPLICATION_JSON))
-                        .andExpect(status().isBadRequest())
-                        .andReturn()
-                        .getResponse()
-                        .getContentAsString();
-
-        assert (Objects.requireNonNull(errorMessage)
-                .contains("Only project owners can see all comments"));
-    }
-
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
     void
-            Test033_ProjectControllerWithNotValidDiscussionIdWhenGettingAllCommentsShouldReturnBadRequest()
+            Test032_ProjectControllerWithNotValidDiscussionIdWhenGettingAllCommentsShouldReturnBadRequest()
                     throws Exception {
 
         String errorMessage =
                 mvc.perform(
                                 MockMvcRequestBuilders.get(
-                                                baseUrl + "/all-comments/" + UUID.randomUUID())
+                                                baseUrl + "/comments/" + UUID.randomUUID())
                                         .accept(MediaType.APPLICATION_JSON))
                         .andExpect(status().isBadRequest())
                         .andReturn()
@@ -916,7 +893,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
     void
-            Test034_ProjectControllerWithValidDiscussionIdWhenGettingAllCommentsShouldReturnHttpOkTest()
+            Test033_ProjectControllerWithValidDiscussionIdWhenGettingCommentsAsOwnerShouldReturnHttpOkTest()
                     throws Exception {
 
         val discussion = projectRepository.findByTitle("Kubernetes").get().getDiscussions().get(0);
@@ -924,7 +901,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
         String contentAsString =
                 mvc.perform(
                                 MockMvcRequestBuilders.get(
-                                                baseUrl + "/all-comments/" + discussion.getId())
+                                                baseUrl + "/comments/" + discussion.getId())
                                         .accept(MediaType.APPLICATION_JSON))
                         .andExpect(status().isOk())
                         .andReturn()
@@ -940,26 +917,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
     void
-            Test035_ProjectControllerWithNotValidDiscussionIdWhenGettingFilteredCommentsShouldReturnBadRequest()
-                    throws Exception {
-
-        String errorMessage =
-                mvc.perform(
-                                MockMvcRequestBuilders.get(
-                                                baseUrl + "/filtered-comments/" + UUID.randomUUID())
-                                        .accept(MediaType.APPLICATION_JSON))
-                        .andExpect(status().isBadRequest())
-                        .andReturn()
-                        .getResponse()
-                        .getContentAsString();
-
-        assert (Objects.requireNonNull(errorMessage).contains("The discussion with id"));
-    }
-
-    @Test
-    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
-    void
-            Test036_ProjectControllerWithValidDiscussionIdWhenGettingFilteredCommentsShouldReturnHttpOkTest()
+            Test034_ProjectControllerWithValidDiscussionIdWhenGettingCommentsAsCollaboratorShouldReturnHttpOkTest()
                     throws Exception {
 
         val discussion = projectRepository.findByTitle("Django").get().getDiscussions().get(0);
@@ -967,9 +925,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
         String contentAsString =
                 mvc.perform(
                                 MockMvcRequestBuilders.get(
-                                                baseUrl
-                                                        + "/filtered-comments/"
-                                                        + discussion.getId())
+                                                baseUrl + "/comments/" + discussion.getId())
                                         .accept(MediaType.APPLICATION_JSON))
                         .andExpect(status().isOk())
                         .andReturn()

--- a/src/test/java/com/a2/backend/repository/DiscussionRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/DiscussionRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.a2.backend.BackendApplication;
 import com.a2.backend.entity.*;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import lombok.val;
@@ -27,6 +28,8 @@ public class DiscussionRepositoryTest {
     @Autowired private ProjectRepository projectRepository;
 
     @Autowired private UserRepository userRepository;
+
+    @Autowired private CommentRepository commentRepository;
 
     @Autowired private DiscussionRepository discussionRepository;
     String title = "New project";
@@ -54,12 +57,21 @@ public class DiscussionRepositoryTest {
                     .reviews(List.of())
                     .build();
 
+    Comment comment =
+            Comment.builder()
+                    .comment("Discussion comment")
+                    .user(owner)
+                    .date(LocalDateTime.now())
+                    .highlighted(false)
+                    .hidden(false)
+                    .build();
+
     Discussion discussion =
             Discussion.builder()
                     .title("Discussion")
                     .project(project)
                     .forumTags(forumTags)
-                    .comments(List.of())
+                    .comments(List.of(comment))
                     .build();
 
     @Test
@@ -158,6 +170,40 @@ public class DiscussionRepositoryTest {
         discussionRepository.save(discussion);
         Discussion savedDiscussion =
                 discussionRepository.findByProjectIdAndTitle(savedProject.getId(), "NotDiscussion");
+    }
+
+    @Test
+    void Test003_DiscussionRepositoryShouldGetDiscussionByCommentId() {
+        userRepository.save(owner);
+
+        assertTrue(projectRepository.findAll().isEmpty());
+
+        assertNull(project.getId());
+        assertEquals(project.getTitle(), title);
+        assertEquals(project.getDescription(), description);
+        assertEquals(project.getOwner(), owner);
+
+        projectRepository.save(project);
+
+        assertFalse(projectRepository.findAll().isEmpty());
+
+        List<Project> projects = projectRepository.findAll();
+
+        assertEquals(1, projects.size());
+
+        val savedProject = projects.get(0);
+
+        assertNotNull(savedProject.getId());
+        assertEquals(savedProject.getTitle(), title);
+        assertEquals(savedProject.getDescription(), description);
+        assertEquals(savedProject.getOwner(), owner);
+
+        val savedDiscussion = discussionRepository.save(discussion);
+
+        val discussion = discussionRepository.findDiscussionByCommentId(comment.getId());
+
+        assertNotNull(discussion);
+        assertEquals(savedDiscussion.getId(), discussion.get().getId());
     }
 
     @Test

--- a/src/test/java/com/a2/backend/service/impl/CommentServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/CommentServiceActiveTest.java
@@ -1,12 +1,15 @@
 package com.a2.backend.service.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.a2.backend.entity.Comment;
+import com.a2.backend.exception.CommentNotFoundException;
 import com.a2.backend.model.CommentCreateDTO;
+import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.service.CommentService;
 import com.a2.backend.service.UserService;
+import java.util.UUID;
+import lombok.val;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -16,6 +19,8 @@ public class CommentServiceActiveTest extends AbstractServiceTest {
     @Autowired private UserService userService;
 
     @Autowired private CommentService commentService;
+
+    @Autowired private ProjectRepository projectRepository;
 
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
@@ -27,5 +32,161 @@ public class CommentServiceActiveTest extends AbstractServiceTest {
         assertEquals("comment", comment.getComment());
         assertNotNull(comment.getDate());
         assertEquals(userService.getLoggedUser(), comment.getUser());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test002_CommentServiceWhenReceiveNotValidCommentIdToHighlightShouldThrowException() {
+        assertThrows(
+                CommentNotFoundException.class,
+                () -> commentService.changeHighlight(UUID.randomUUID()));
+    }
+
+    @Test
+    @WithMockUser("agustin.ayerza@ing.austral.edu.ar")
+    void Test003_CommentServiceWithHighlightedCommentWhenChangingHighlightShouldChangeToFalse() {
+        val comment =
+                projectRepository
+                        .findByTitle("Django")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(1);
+
+        assertTrue(comment.isHighlighted());
+
+        val updatedComment = commentService.changeHighlight(comment.getId());
+
+        assertNotNull(updatedComment);
+        assertEquals(updatedComment.getId(), comment.getId());
+        assertFalse(comment.isHighlighted());
+        assertEquals(comment.isHidden(), updatedComment.isHidden());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test004_CommentServiceWithNotHighlightedCommentWhenChangingHighlightShouldChangeToTrueAndChangeHiddenWhenTrue() {
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(1);
+
+        assertFalse(comment.isHighlighted());
+        assertTrue(comment.isHidden());
+
+        val updatedComment = commentService.changeHighlight(comment.getId());
+
+        assertNotNull(updatedComment);
+        assertEquals(updatedComment.getId(), comment.getId());
+        assertTrue(comment.isHighlighted());
+        assertFalse(comment.isHidden());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test005_CommentServiceWithNotHighlightedCommentWhenChangingHighlightShouldChangeToTrueAndDontChangeHiddenWhenFalse() {
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(0);
+
+        assertFalse(comment.isHighlighted());
+        assertFalse(comment.isHidden());
+
+        val updatedComment = commentService.changeHighlight(comment.getId());
+
+        assertNotNull(updatedComment);
+        assertEquals(updatedComment.getId(), comment.getId());
+        assertTrue(comment.isHighlighted());
+        assertFalse(comment.isHidden());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test006_CommentServiceWhenReceiveNotValidCommentIdToHideShouldThrowException() {
+        assertThrows(
+                CommentNotFoundException.class,
+                () -> commentService.changeHidden(UUID.randomUUID()));
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test007_CommentServiceWithHiddenCommentWhenChangingHiddenShouldChangeToFalse() {
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(1);
+
+        assertTrue(comment.isHidden());
+
+        val updatedComment = commentService.changeHidden(comment.getId());
+
+        assertNotNull(updatedComment);
+        assertEquals(updatedComment.getId(), comment.getId());
+        assertFalse(comment.isHidden());
+        assertEquals(comment.isHighlighted(), updatedComment.isHighlighted());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test008_CommentServiceWithNotHiddenCommentWhenChangingHiddenShouldChangeToTrueAndChangeHighlightedWhenTrue() {
+        val comment =
+                projectRepository
+                        .findByTitle("Django")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(1);
+
+        assertFalse(comment.isHidden());
+        assertTrue(comment.isHighlighted());
+
+        val updatedComment = commentService.changeHidden(comment.getId());
+
+        assertNotNull(updatedComment);
+        assertEquals(updatedComment.getId(), comment.getId());
+        assertFalse(comment.isHighlighted());
+        assertTrue(comment.isHidden());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test009_CommentServiceWithNotHiddenCommentWhenChangingHiddenShouldChangeToTrueAndDontChangeHighlightWhenFalse() {
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(0);
+
+        assertFalse(comment.isHighlighted());
+        assertFalse(comment.isHidden());
+
+        val updatedComment = commentService.changeHidden(comment.getId());
+
+        assertNotNull(updatedComment);
+        assertEquals(updatedComment.getId(), comment.getId());
+        assertFalse(comment.isHighlighted());
+        assertTrue(comment.isHidden());
     }
 }

--- a/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
@@ -222,7 +222,8 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
 
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
-    void Test012_DiscussionServiceWithValidCommentIdWhenGettingCommentShouldReturnCommentList() {
+    void
+            Test012_DiscussionServiceWithValidCommentIdWhenGettingCommentsAsOwnerShouldReturnListWithAllComments() {
 
         val discussion = projectRepository.findByTitle("Kubernetes").get().getDiscussions().get(0);
 
@@ -230,33 +231,35 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
 
         assertNotNull(comments);
         assertEquals(2, comments.size());
-        assertEquals(-1, comments.get(0).getDate().compareTo(comments.get(1).getDate()));
+        assertTrue(comments.get(0).getDate().isBefore(comments.get(1).getDate()));
     }
 
     @Test
     @WithMockUser("agustin.ayerza@ing.austral.edu.ar")
     void
-            Test011_DiscussionServiceWithNotValidDiscussionIdWhenGettingCommentsInOrderShouldThrowException() {
+            Test013_DiscussionServiceWithValidCommentIdWhenGettingCommentsAsCollaboratorShouldReturnListWithFilteredComments() {
 
-        assertThrows(
-                DiscussionNotFoundException.class,
-                () -> discussionService.getFilteredComments(UUID.randomUUID()));
+        val discussion = projectRepository.findByTitle("Kubernetes").get().getDiscussions().get(0);
+
+        val comments = discussionService.getComments(discussion.getId());
+
+        assertNotNull(comments);
+        assertEquals(1, comments.size());
     }
 
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
     void
-            Test012_DiscussionServiceWithValidCommentIdWhenGettingCommentsInOrderShouldReturnCommentList() {
+            Test014_DiscussionServiceWithValidCommentIdWhenGettingCommentsAsCollaboratorShouldReturnFilteredCommentListInOrder() {
 
         val discussion = projectRepository.findByTitle("Django").get().getDiscussions().get(0);
 
-        val comments = discussionService.getFilteredComments(discussion.getId());
+        val comments = discussionService.getComments(discussion.getId());
 
         assertNotNull(comments);
         assertEquals(3, comments.size());
         assertTrue(comments.get(0).getComment().contains("The method handlers for a ViewSet"));
         assertTrue(comments.get(1).getComment().contains("The ViewSet class inherits"));
         assertTrue(comments.get(2).getComment().contains("A ViewSet class is simply"));
-
     }
 }

--- a/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
@@ -257,5 +257,6 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
         assertTrue(comments.get(0).getComment().contains("The method handlers for a ViewSet"));
         assertTrue(comments.get(1).getComment().contains("The ViewSet class inherits"));
         assertTrue(comments.get(2).getComment().contains("A ViewSet class is simply"));
+
     }
 }

--- a/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
@@ -12,6 +12,7 @@ import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.service.DiscussionService;
 import java.util.List;
 import java.util.UUID;
+import lombok.val;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -108,5 +109,153 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
         assertThrows(
                 UserIsNotOwnerException.class,
                 () -> discussionService.deleteDiscussion(discussion.getId()));
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test005_DiscussionServiceWithInvalidCommentIdWhenHighlightingCommentShouldThrowException() {
+        assertThrows(
+                DiscussionNotFoundException.class,
+                () -> discussionService.changeCommentHighlight(UUID.randomUUID()));
+    }
+
+    @Test
+    @WithMockUser("agustin.ayerza@ing.austral.edu.ar")
+    void
+            Test006_DiscussionServiceWithValidCommentIdButNotProjectOwnerWhenHighlightingCommentShouldThrowException() {
+
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(0);
+
+        assertThrows(
+                InvalidUserException.class,
+                () -> discussionService.changeCommentHighlight(comment.getId()));
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test007_DiscussionServiceWithValidCommentIdWhenHighlightingCommentShouldUpdateComment() {
+
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(0);
+
+        assertFalse(comment.isHidden());
+        assertFalse(comment.isHighlighted());
+
+        val commentDto = discussionService.changeCommentHighlight(comment.getId());
+
+        assertFalse(comment.isHidden());
+        assertTrue(comment.isHighlighted());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test008_DiscussionServiceWithInvalidCommentIdWhenHidingCommentShouldThrowException() {
+        assertThrows(
+                DiscussionNotFoundException.class,
+                () -> discussionService.changeCommentHidden(UUID.randomUUID()));
+    }
+
+    @Test
+    @WithMockUser("agustin.ayerza@ing.austral.edu.ar")
+    void
+            Test009_DiscussionServiceWithValidCommentIdButNotProjectOwnerWhenHidingCommentShouldThrowException() {
+
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(0);
+
+        assertThrows(
+                InvalidUserException.class,
+                () -> discussionService.changeCommentHidden(comment.getId()));
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test010_DiscussionServiceWithValidCommentIdWhenHidingCommentShouldUpdateComment() {
+
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(0);
+
+        assertFalse(comment.isHidden());
+        assertFalse(comment.isHighlighted());
+
+        val commentDto = discussionService.changeCommentHidden(comment.getId());
+
+        assertTrue(comment.isHidden());
+        assertFalse(comment.isHighlighted());
+    }
+
+    @Test
+    @WithMockUser("agustin.ayerza@ing.austral.edu.ar")
+    void
+            Test011_DiscussionServiceWithNotValidDiscussionIdWhenGettingCommentsShouldThrowException() {
+
+        assertThrows(
+                DiscussionNotFoundException.class,
+                () -> discussionService.getComments(UUID.randomUUID()));
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test012_DiscussionServiceWithValidCommentIdWhenGettingCommentShouldReturnCommentList() {
+
+        val discussion = projectRepository.findByTitle("Kubernetes").get().getDiscussions().get(0);
+
+        val comments = discussionService.getComments(discussion.getId());
+
+        assertNotNull(comments);
+        assertEquals(2, comments.size());
+        assertEquals(-1, comments.get(0).getDate().compareTo(comments.get(1).getDate()));
+    }
+
+    @Test
+    @WithMockUser("agustin.ayerza@ing.austral.edu.ar")
+    void
+            Test011_DiscussionServiceWithNotValidDiscussionIdWhenGettingCommentsInOrderShouldThrowException() {
+
+        assertThrows(
+                DiscussionNotFoundException.class,
+                () -> discussionService.getFilteredComments(UUID.randomUUID()));
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test012_DiscussionServiceWithValidCommentIdWhenGettingCommentsInOrderShouldReturnCommentList() {
+
+        val discussion = projectRepository.findByTitle("Django").get().getDiscussions().get(0);
+
+        val comments = discussionService.getFilteredComments(discussion.getId());
+
+        assertNotNull(comments);
+        assertEquals(3, comments.size());
+        assertTrue(comments.get(0).getComment().contains("The method handlers for a ViewSet"));
+        assertTrue(comments.get(1).getComment().contains("The ViewSet class inherits"));
+        assertTrue(comments.get(2).getComment().contains("A ViewSet class is simply"));
     }
 }


### PR DESCRIPTION
Como usuario dueño de proyecto quiero poder esconder o resaltar respuestas sobre discusiones en la pantalla de comentarios sobre discusiones de forma de poder controlar que se muestra mas o no se debe mostrar en las discusiones de mi proyecto

UAT:

Desde la pantalla de visualizacion de una discusion el usuario owner debe poder modificar acceder a dos botones sobre cada respuesta, uno para esconder y otro para resaltar la respuesta.
Cuando se marca que una respuesta esta escondida esta quedara con el boton correspondiente como activado, de forma de que se pueda saber que esta escondida.
Cuando se marca que una respuesta esta resltada esta quedara con el boton correspondiente como activado, de forma de que se pueda saber que esta resaltada.
Cuando una respuesta esta escondida esta no se podra visualizar sobre la pantalla de respuestas como otro usuario que no sea owner
Cuando una respuesta esta resaltada esta se ubicara como primera. Si hubiera varias resaltadas entonces estas se ordenaran por fecha de publicacion como el resto de las respuestas