### PR TITLE
Delete Discussion implemented

### DIFF
--- a/src/main/java/com/a2/backend/controller/DiscussionController.java
+++ b/src/main/java/com/a2/backend/controller/DiscussionController.java
@@ -27,4 +27,11 @@ public class DiscussionController {
         val updatedDiscussion = discussionService.updateDiscussion(id, discussionUpdateDTO);
         return ResponseEntity.status(HttpStatus.OK).body(updatedDiscussion);
     }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteDiscussion(@PathVariable UUID id) {
+        discussionService.deleteDiscussion(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/a2/backend/service/DiscussionService.java
+++ b/src/main/java/com/a2/backend/service/DiscussionService.java
@@ -17,4 +17,6 @@ public interface DiscussionService {
             UUID discussionId, DiscussionUpdateDTO discussionUpdateDTO);
 
     public DiscussionDTO getDiscussionDetails(UUID discussionID);
+
+    void deleteDiscussion(UUID discussionID);
 }

--- a/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
@@ -163,4 +163,23 @@ public class DiscussionServiceImpl implements DiscussionService {
                                         String.format(
                                                 "No discussion found for id: %s", discussionID)));
     }
+
+    @Override
+    public void deleteDiscussion(UUID discussionID) {
+        val loggedUser = userService.getLoggedUser();
+        val discussionToDelete = discussionRepository.findById(discussionID);
+        val project = projectRepository.findById(discussionToDelete.get().getProject().getId());
+        if (discussionToDelete.isEmpty()) {
+            throw new DiscussionNotFoundException("Discussion not found!");
+        }
+        if (!discussionRepository.getById(discussionID).getOwner().equals(loggedUser)) {
+            throw new UserIsNotOwnerException(
+                    String.format("User: %s is not the owner!", loggedUser.getNickname()));
+        }
+        if (project.isEmpty()) {
+            throw new ProjectNotFoundException("Project does not exist!");
+        }
+        project.get().getDiscussions().remove(discussionToDelete.get());
+        discussionRepository.deleteById(discussionID);
+    }
 }

--- a/src/test/java/com/a2/backend/repository/DiscussionRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/DiscussionRepositoryTest.java
@@ -159,4 +159,33 @@ public class DiscussionRepositoryTest {
         Discussion savedDiscussion =
                 discussionRepository.findByProjectIdAndTitle(savedProject.getId(), "NotDiscussion");
     }
+
+    @Test
+    void Test005_DiscussionRepositoryShouldDeleteDiscussion() {
+        userRepository.save(owner);
+
+        assertTrue(projectRepository.findAll().isEmpty());
+
+        assertNull(project.getId());
+        assertEquals(project.getTitle(), title);
+        assertEquals(project.getDescription(), description);
+        assertEquals(project.getOwner(), owner);
+
+        projectRepository.save(project);
+
+        assertFalse(projectRepository.findAll().isEmpty());
+
+        List<Project> projects = projectRepository.findAll();
+
+        assertEquals(1, projects.size());
+
+        val savedProject = projects.get(0);
+
+        discussionRepository.save(discussion);
+        assertFalse(discussionRepository.findAll().isEmpty());
+
+        discussionRepository.deleteById(discussion.getId());
+
+        assertTrue(discussionRepository.findAll().isEmpty());
+    }
 }

--- a/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
@@ -6,6 +6,7 @@ import com.a2.backend.entity.Comment;
 import com.a2.backend.entity.Discussion;
 import com.a2.backend.exception.DiscussionNotFoundException;
 import com.a2.backend.exception.InvalidUserException;
+import com.a2.backend.exception.UserIsNotOwnerException;
 import com.a2.backend.model.CommentCreateDTO;
 import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.service.DiscussionService;
@@ -86,5 +87,26 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
 
         assertTrue(comments.get(0).getDate().isBefore(comments.get(1).getDate()));
         assertTrue(comments.get(1).getDate().isBefore(comments.get(2).getDate()));
+    }
+
+    @Test
+    @WithMockUser("agustin.ayerza@ing.austral.edu.ar")
+    void Test005_GivenValidIDAndOwnerWhenWantToDeleteADiscussionThenDeleteDiscussion() {
+        Discussion discussion =
+                projectRepository.findByTitle("Django").get().getDiscussions().get(0);
+        assertNotNull(discussion);
+        discussionService.deleteDiscussion(discussion.getId());
+        assertTrue(projectRepository.findByTitle("Django").get().getDiscussions().isEmpty());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test006_GivenAWrongOwnerWhenWantToDeleteADiscussionThenThrowException() {
+        Discussion discussion =
+                projectRepository.findByTitle("Django").get().getDiscussions().get(0);
+        assertNotNull(discussion);
+        assertThrows(
+                UserIsNotOwnerException.class,
+                () -> discussionService.deleteDiscussion(discussion.getId()));
     }
 }


### PR DESCRIPTION
Como usuario creador de una discusión de un proyecto quiero poder eliminar una discusión de la que soy dueño de tal forma de poder eliminar discusiones que no quiero que existan más.

- desde la página de listado de discusiones las discusiones iniciadas por el usuario deben aparecer con un botón para borrar
- cuando este botón se toca aparece un pop up que confirma que el usuario quiere eliminar la discusión 
- Si se confirma la baja se muestra un mensaje que avisa que se eliminó correctamente
- Ante un error se debe mostrar un mensaje de error
