### PR TITLE
User can now delete discussions from the Projects he owns.

### DIFF
--- a/src/main/java/com/a2/backend/DemoRunner.java
+++ b/src/main/java/com/a2/backend/DemoRunner.java
@@ -418,6 +418,7 @@ public class DemoRunner implements CommandLineRunner {
                                 .title("Not working on MacOS")
                                 .forumTags(List.of(forumTagRepository.findByName("help").get()))
                                 .project(kubernetes)
+                                .owner(franz)
                                 .comments(
                                         List.of(
                                                 Comment.builder()

--- a/src/main/java/com/a2/backend/DemoRunner.java
+++ b/src/main/java/com/a2/backend/DemoRunner.java
@@ -392,6 +392,7 @@ public class DemoRunner implements CommandLineRunner {
                                 .title("Not working on MacOS")
                                 .forumTags(List.of(forumTagRepository.findByName("help").get()))
                                 .project(kubernetes)
+                                .owner(franz)
                                 .comments(
                                         List.of(
                                                 Comment.builder()

--- a/src/main/java/com/a2/backend/DemoRunner.java
+++ b/src/main/java/com/a2/backend/DemoRunner.java
@@ -384,6 +384,32 @@ public class DemoRunner implements CommandLineRunner {
                                                                 "A ViewSet class is simply a type of class-based View, that does not provide any method handlers such as .get() or .post(), and instead provides actions such as .list() and .create().")
                                                         .user(peltevis)
                                                         .date(LocalDateTime.now())
+                                                        .highlighted(false)
+                                                        .hidden(false)
+                                                        .build(),
+                                                Comment.builder()
+                                                        .comment(
+                                                                "The method handlers for a ViewSet are only bound to the corresponding actions at the point of finalizing the view, using the .as_view() method.")
+                                                        .user(peltevis)
+                                                        .date(LocalDateTime.now().plusNanos(1))
+                                                        .highlighted(true)
+                                                        .hidden(false)
+                                                        .build(),
+                                                Comment.builder()
+                                                        .comment(
+                                                                "An advantage of using a ViewSet class over using a View class is that repeated logic can be combined into a single class.")
+                                                        .user(peltevis)
+                                                        .date(LocalDateTime.now().plusNanos(2))
+                                                        .highlighted(false)
+                                                        .hidden(true)
+                                                        .build(),
+                                                Comment.builder()
+                                                        .comment(
+                                                                "The ViewSet class inherits from APIView. You can use any of the standard attributes such as permission_classes, authentication_classes in order to control the API policy on the viewset.")
+                                                        .user(peltevis)
+                                                        .date(LocalDateTime.now().plusNanos(3))
+                                                        .highlighted(true)
+                                                        .hidden(false)
                                                         .build()))
                                 .build()));
         kubernetes.setDiscussions(
@@ -398,11 +424,15 @@ public class DemoRunner implements CommandLineRunner {
                                                         .comment("You should try a reinstall")
                                                         .user(franz)
                                                         .date(LocalDateTime.now())
+                                                        .highlighted(false)
+                                                        .hidden(false)
                                                         .build(),
                                                 Comment.builder()
                                                         .comment("Or maybe just a reboot first...")
                                                         .user(ropa1998)
                                                         .date(LocalDateTime.now().plusNanos(1))
+                                                        .highlighted(false)
+                                                        .hidden(true)
                                                         .build()))
                                 .build(),
                         Discussion.builder()

--- a/src/main/java/com/a2/backend/controller/ProjectController.java
+++ b/src/main/java/com/a2/backend/controller/ProjectController.java
@@ -176,4 +176,25 @@ public class ProjectController {
         val comment = discussionService.createComment(discussionId, commentCreateDTO);
         return ResponseEntity.status(HttpStatus.OK).body(comment);
     }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @PutMapping("/highlight/{commentId}")
+    public ResponseEntity<?> highlightComment(@PathVariable UUID commentId) {
+        val comment = discussionService.changeCommentHighlight(commentId);
+        return ResponseEntity.status(HttpStatus.OK).body(comment);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @PutMapping("/hide/{commentId}")
+    public ResponseEntity<?> hideComment(@PathVariable UUID commentId) {
+        val comment = discussionService.changeCommentHidden(commentId);
+        return ResponseEntity.status(HttpStatus.OK).body(comment);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @GetMapping("/comments/{discussionId}")
+    public ResponseEntity<?> getCommentsInDiscussion(@PathVariable UUID discussionId) {
+        val comments = discussionService.getComments(discussionId);
+        return ResponseEntity.status(HttpStatus.OK).body(comments);
+    }
 }

--- a/src/main/java/com/a2/backend/entity/Comment.java
+++ b/src/main/java/com/a2/backend/entity/Comment.java
@@ -28,7 +28,18 @@ public class Comment {
 
     private LocalDateTime date;
 
+    private boolean hidden;
+
+    private boolean highlighted;
+
     public CommentDTO toDTO() {
-        return CommentDTO.builder().id(id).user(user.toDTO()).comment(comment).date(date).build();
+        return CommentDTO.builder()
+                .id(id)
+                .user(user.toDTO())
+                .comment(comment)
+                .date(date)
+                .hidden(hidden)
+                .highlighted(highlighted)
+                .build();
     }
 }

--- a/src/main/java/com/a2/backend/exception/CommentNotFoundException.java
+++ b/src/main/java/com/a2/backend/exception/CommentNotFoundException.java
@@ -1,0 +1,7 @@
+package com.a2.backend.exception;
+
+public class CommentNotFoundException extends RuntimeException {
+    public CommentNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
+++ b/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
@@ -139,4 +139,10 @@ public class DefaultExceptionHandler {
         logger.info(exception.getMessage());
         return new ResponseEntity(exception.getMessage(), HttpStatus.UNAUTHORIZED);
     }
+
+    @ExceptionHandler(CommentNotFoundException.class)
+    protected ResponseEntity<?> handleCommentNotFound(CommentNotFoundException exception) {
+        logger.info(exception.getMessage());
+        return new ResponseEntity(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/a2/backend/model/CommentDTO.java
+++ b/src/main/java/com/a2/backend/model/CommentDTO.java
@@ -19,4 +19,8 @@ public class CommentDTO {
     private String comment;
 
     private LocalDateTime date;
+
+    private boolean hidden;
+
+    private boolean highlighted;
 }

--- a/src/main/java/com/a2/backend/model/ReviewCreateDTO.java
+++ b/src/main/java/com/a2/backend/model/ReviewCreateDTO.java
@@ -17,7 +17,7 @@ public class ReviewCreateDTO {
 
     @NotNull private UUID collaboratorID;
 
-    @Size(min = 10, max = 500, message = "Comment should be between 10 and 500 characters")
+    @Size(max = 500, message = "Comment should be between 10 and 500 characters")
     private String comment;
 
     @NotNull

--- a/src/main/java/com/a2/backend/repository/DiscussionRepository.java
+++ b/src/main/java/com/a2/backend/repository/DiscussionRepository.java
@@ -10,5 +10,8 @@ public interface DiscussionRepository extends JpaRepository<Discussion, UUID> {
     @Query("SELECT d FROM Discussion d WHERE d.title LIKE ?2 AND d.project.id=?1")
     Discussion findByProjectIdAndTitle(UUID id, String title);
 
+    @Query("SELECT DISTINCT d FROM Discussion d JOIN d.comments c WHERE UPPER(c.id) = ?1 ")
+    Optional<Discussion> findDiscussionByCommentId(UUID commentId);
+
     Optional<Discussion> findByTitle(String title);
 }

--- a/src/main/java/com/a2/backend/service/CommentService.java
+++ b/src/main/java/com/a2/backend/service/CommentService.java
@@ -2,8 +2,13 @@ package com.a2.backend.service;
 
 import com.a2.backend.entity.Comment;
 import com.a2.backend.model.CommentCreateDTO;
+import java.util.UUID;
 
 public interface CommentService {
 
     Comment createComment(CommentCreateDTO commentCreateDTO);
+
+    Comment changeHighlight(UUID commentId);
+
+    Comment changeHidden(UUID commentId);
 }

--- a/src/main/java/com/a2/backend/service/DiscussionService.java
+++ b/src/main/java/com/a2/backend/service/DiscussionService.java
@@ -12,12 +12,11 @@ public interface DiscussionService {
 
     CommentDTO createComment(UUID discussionId, CommentCreateDTO commentCreateDTO);
 
-    public DiscussionDTO createDiscussion(UUID projectId, DiscussionCreateDTO discussionCreateDTO);
+    DiscussionDTO createDiscussion(UUID projectId, DiscussionCreateDTO discussionCreateDTO);
 
-    public DiscussionDTO updateDiscussion(
-            UUID discussionId, DiscussionUpdateDTO discussionUpdateDTO);
+    DiscussionDTO updateDiscussion(UUID discussionId, DiscussionUpdateDTO discussionUpdateDTO);
 
-    public DiscussionDTO getDiscussionDetails(UUID discussionID);
+    DiscussionDTO getDiscussionDetails(UUID discussionID);
 
     void deleteDiscussion(UUID discussionID);
 

--- a/src/main/java/com/a2/backend/service/DiscussionService.java
+++ b/src/main/java/com/a2/backend/service/DiscussionService.java
@@ -11,12 +11,11 @@ public interface DiscussionService {
 
     CommentDTO createComment(UUID discussionId, CommentCreateDTO commentCreateDTO);
 
-    public DiscussionDTO createDiscussion(UUID projectId, DiscussionCreateDTO discussionCreateDTO);
+    DiscussionDTO createDiscussion(UUID projectId, DiscussionCreateDTO discussionCreateDTO);
 
-    public DiscussionDTO updateDiscussion(
-            UUID discussionId, DiscussionUpdateDTO discussionUpdateDTO);
+    DiscussionDTO updateDiscussion(UUID discussionId, DiscussionUpdateDTO discussionUpdateDTO);
 
-    public DiscussionDTO getDiscussionDetails(UUID discussionID);
+    DiscussionDTO getDiscussionDetails(UUID discussionID);
 
     void deleteDiscussion(UUID discussionID);
 }

--- a/src/main/java/com/a2/backend/service/DiscussionService.java
+++ b/src/main/java/com/a2/backend/service/DiscussionService.java
@@ -5,6 +5,7 @@ import com.a2.backend.model.CommentDTO;
 import com.a2.backend.model.DiscussionCreateDTO;
 import com.a2.backend.model.DiscussionDTO;
 import com.a2.backend.model.DiscussionUpdateDTO;
+import java.util.List;
 import java.util.UUID;
 
 public interface DiscussionService {
@@ -19,4 +20,10 @@ public interface DiscussionService {
     public DiscussionDTO getDiscussionDetails(UUID discussionID);
 
     void deleteDiscussion(UUID discussionID);
+
+    CommentDTO changeCommentHighlight(UUID commentId);
+
+    CommentDTO changeCommentHidden(UUID commentId);
+
+    List<CommentDTO> getComments(UUID discussionId);
 }

--- a/src/main/java/com/a2/backend/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/CommentServiceImpl.java
@@ -1,18 +1,25 @@
 package com.a2.backend.service.impl;
 
 import com.a2.backend.entity.Comment;
+import com.a2.backend.exception.CommentNotFoundException;
 import com.a2.backend.model.CommentCreateDTO;
+import com.a2.backend.repository.CommentRepository;
 import com.a2.backend.service.CommentService;
 import com.a2.backend.service.UserService;
 import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.val;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CommentServiceImpl implements CommentService {
     private final UserService userService;
 
-    public CommentServiceImpl(UserService userService) {
+    private final CommentRepository commentRepository;
+
+    public CommentServiceImpl(UserService userService, CommentRepository commentRepository) {
         this.userService = userService;
+        this.commentRepository = commentRepository;
     }
 
     @Override
@@ -21,6 +28,48 @@ public class CommentServiceImpl implements CommentService {
                 .user(userService.getLoggedUser())
                 .comment(commentCreateDTO.getComment())
                 .date(LocalDateTime.now())
+                .hidden(false)
+                .highlighted(false)
                 .build();
+    }
+
+    @Override
+    public Comment changeHighlight(UUID commentId) {
+        val commentOptional = commentRepository.findById(commentId);
+
+        if (commentOptional.isEmpty()) {
+            throw new CommentNotFoundException(
+                    String.format("Comment with id: %s not found", commentId));
+        }
+
+        val comment = commentOptional.get();
+
+        comment.setHighlighted(!comment.isHighlighted());
+
+        if (comment.isHighlighted() && comment.isHidden()) {
+            comment.setHidden(!comment.isHidden());
+        }
+
+        return comment;
+    }
+
+    @Override
+    public Comment changeHidden(UUID commentId) {
+        val commentOptional = commentRepository.findById(commentId);
+
+        if (commentOptional.isEmpty()) {
+            throw new CommentNotFoundException(
+                    String.format("Comment with id: %s not found", commentId));
+        }
+
+        val comment = commentOptional.get();
+
+        comment.setHidden(!comment.isHidden());
+
+        if (comment.isHidden() && comment.isHighlighted()) {
+            comment.setHighlighted(!comment.isHighlighted());
+        }
+
+        return comment;
     }
 }

--- a/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
@@ -175,7 +175,8 @@ public class DiscussionServiceImpl implements DiscussionService {
         if (discussionToDelete.isEmpty()) {
             throw new DiscussionNotFoundException("Discussion not found!");
         }
-        if (!discussionRepository.getById(discussionID).getOwner().equals(loggedUser)) {
+        if (!discussionRepository.getById(discussionID).getOwner().equals(loggedUser)
+                && !project.get().getOwner().equals(loggedUser)) {
             throw new UserIsNotOwnerException(
                     String.format("User: %s is not the owner!", loggedUser.getNickname()));
         }

--- a/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
@@ -172,7 +172,8 @@ public class DiscussionServiceImpl implements DiscussionService {
         if (discussionToDelete.isEmpty()) {
             throw new DiscussionNotFoundException("Discussion not found!");
         }
-        if (!discussionRepository.getById(discussionID).getOwner().equals(loggedUser)) {
+        if (!discussionRepository.getById(discussionID).getOwner().equals(loggedUser)
+                && !project.get().getOwner().equals(loggedUser)) {
             throw new UserIsNotOwnerException(
                     String.format("User: %s is not the owner!", loggedUser.getNickname()));
         }

--- a/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.a2.backend.service.impl;
 
+import com.a2.backend.entity.Comment;
 import com.a2.backend.entity.Discussion;
 import com.a2.backend.entity.ForumTag;
 import com.a2.backend.entity.User;
@@ -15,8 +16,10 @@ import com.a2.backend.service.CommentService;
 import com.a2.backend.service.DiscussionService;
 import com.a2.backend.service.ForumTagService;
 import com.a2.backend.service.UserService;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.transaction.Transactional;
 import lombok.val;
 import org.springframework.stereotype.Service;
@@ -181,5 +184,100 @@ public class DiscussionServiceImpl implements DiscussionService {
         }
         project.get().getDiscussions().remove(discussionToDelete.get());
         discussionRepository.deleteById(discussionID);
+    }
+
+    @Override
+    public CommentDTO changeCommentHighlight(UUID commentId) {
+        User loggedUser = userService.getLoggedUser();
+        val discussionOptional = discussionRepository.findDiscussionByCommentId(commentId);
+
+        if (discussionOptional.isEmpty()) {
+            throw new DiscussionNotFoundException(
+                    String.format("Discussion with comment id: %s not found", commentId));
+        }
+
+        val discussion = discussionOptional.get();
+        val project = discussion.getProject();
+
+        if (!project.getOwner().equals(loggedUser)) {
+            throw new InvalidUserException("Only project owners can highlight comments");
+        }
+
+        val comments = discussionOptional.get().getComments();
+
+        val updatedComment = commentService.changeHighlight(commentId);
+
+        discussion.setComments(comments);
+        discussionRepository.save(discussion);
+
+        return updatedComment.toDTO();
+    }
+
+    @Override
+    public CommentDTO changeCommentHidden(UUID commentId) {
+        User loggedUser = userService.getLoggedUser();
+        val discussionOptional = discussionRepository.findDiscussionByCommentId(commentId);
+
+        if (discussionOptional.isEmpty()) {
+            throw new DiscussionNotFoundException(
+                    String.format("Discussion with comment id: %s not found", commentId));
+        }
+
+        val discussion = discussionOptional.get();
+        val project = discussion.getProject();
+
+        if (!project.getOwner().equals(loggedUser)) {
+            throw new InvalidUserException("Only project owners can hide comments");
+        }
+
+        val comments = discussionOptional.get().getComments();
+
+        val updatedComment = commentService.changeHidden(commentId);
+
+        discussion.setComments(comments);
+        discussionRepository.save(discussion);
+
+        return updatedComment.toDTO();
+    }
+
+    @Override
+    public List<CommentDTO> getComments(UUID discussionId) {
+        User loggedUser = userService.getLoggedUser();
+        val discussionOptional = discussionRepository.findById(discussionId);
+
+        if (discussionOptional.isEmpty()) {
+            throw new DiscussionNotFoundException(
+                    String.format("The discussion with id: %s does not exist!", discussionId));
+        }
+
+        val discussion = discussionOptional.get();
+        val project = discussion.getProject();
+
+        List<CommentDTO> comments =
+                discussionOptional.get().getComments().stream()
+                        .map(Comment::toDTO)
+                        .collect(Collectors.toList());
+
+        if (project.getOwner().equals(loggedUser)) {
+
+            comments.sort(Comparator.comparing(CommentDTO::getDate));
+            return comments;
+
+        } else {
+            List<CommentDTO> highlighted =
+                    comments.stream()
+                            .filter(CommentDTO::isHighlighted)
+                            .collect(Collectors.toList());
+            highlighted.sort(Comparator.comparing(CommentDTO::getDate));
+            List<CommentDTO> others =
+                    comments.stream()
+                            .filter(c -> !c.isHighlighted() && !c.isHidden())
+                            .collect(Collectors.toList());
+            others.sort(Comparator.comparing(CommentDTO::getDate));
+
+            highlighted.addAll(others);
+
+            return highlighted;
+        }
     }
 }

--- a/src/test/java/com/a2/backend/controller/ProjectControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/ProjectControllerActiveTest.java
@@ -1,7 +1,6 @@
 package com.a2.backend.controller;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.a2.backend.entity.Comment;
@@ -724,7 +723,224 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
 
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
-    void Test0038_ProjectControllerWhenReceivesValidUpdateDiscussionDTOshouldReturnOK()
+    void Test026_ProjectControllerWithValidCommentIdWhenHighlightingShouldReturnHttpOkTest()
+            throws Exception {
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(0);
+
+        assertFalse(comment.isHighlighted());
+
+        String contentAsString =
+                mvc.perform(
+                                MockMvcRequestBuilders.put(
+                                                baseUrl + "/highlight/" + comment.getId())
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        val updatedComment = objectMapper.readValue(contentAsString, CommentDTO.class);
+
+        assertEquals(comment.getId(), updatedComment.getId());
+        assertTrue(updatedComment.isHighlighted());
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void Test027_ProjectControllerWithNotValidCommentIdWhenHighlightingShouldReturnBadRequest()
+            throws Exception {
+
+        String errorMessage =
+                mvc.perform(
+                                MockMvcRequestBuilders.put(
+                                                baseUrl + "/highlight/" + UUID.randomUUID())
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isBadRequest())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        assert (Objects.requireNonNull(errorMessage).contains("Discussion with comment id"));
+    }
+
+    @Test
+    @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
+    void
+            Test028_ProjectControllerWithValidCommentIdButNotOwnerWhenHighlightingShouldReturnBadRequest()
+                    throws Exception {
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(0);
+
+        String errorMessage =
+                mvc.perform(
+                                MockMvcRequestBuilders.put(
+                                                baseUrl + "/highlight/" + comment.getId())
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isBadRequest())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        assert (Objects.requireNonNull(errorMessage)
+                .contains("Only project owners can highlight comments"));
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void Test029_ProjectControllerWithValidCommentIdWhenHidingShouldReturnHttpOkTest()
+            throws Exception {
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(0);
+
+        assertFalse(comment.isHidden());
+
+        String contentAsString =
+                mvc.perform(
+                                MockMvcRequestBuilders.put(baseUrl + "/hide/" + comment.getId())
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        val updatedComment = objectMapper.readValue(contentAsString, CommentDTO.class);
+
+        assertEquals(comment.getId(), updatedComment.getId());
+        assertTrue(updatedComment.isHidden());
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void Test030_ProjectControllerWithNotValidCommentIdWhenHidingShouldReturnBadRequest()
+            throws Exception {
+
+        String errorMessage =
+                mvc.perform(
+                                MockMvcRequestBuilders.put(baseUrl + "/hide/" + UUID.randomUUID())
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isBadRequest())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        assert (Objects.requireNonNull(errorMessage).contains("Discussion with comment id"));
+    }
+
+    @Test
+    @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
+    void Test031_ProjectControllerWithValidCommentIdButNotOwnerWhenHidingShouldReturnBadRequest()
+            throws Exception {
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(0);
+
+        String errorMessage =
+                mvc.perform(
+                                MockMvcRequestBuilders.put(baseUrl + "/hide/" + comment.getId())
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isBadRequest())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        assert (Objects.requireNonNull(errorMessage)
+                .contains("Only project owners can hide comments"));
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test032_ProjectControllerWithNotValidDiscussionIdWhenGettingAllCommentsShouldReturnBadRequest()
+                    throws Exception {
+
+        String errorMessage =
+                mvc.perform(
+                                MockMvcRequestBuilders.get(
+                                                baseUrl + "/comments/" + UUID.randomUUID())
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isBadRequest())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        assert (Objects.requireNonNull(errorMessage).contains("The discussion with id"));
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test033_ProjectControllerWithValidDiscussionIdWhenGettingCommentsAsOwnerShouldReturnHttpOkTest()
+                    throws Exception {
+
+        val discussion = projectRepository.findByTitle("Kubernetes").get().getDiscussions().get(0);
+
+        String contentAsString =
+                mvc.perform(
+                                MockMvcRequestBuilders.get(
+                                                baseUrl + "/comments/" + discussion.getId())
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        val comments = objectMapper.readValue(contentAsString, CommentDTO[].class);
+
+        assertNotNull(comments);
+        assertEquals(2, comments.length);
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test034_ProjectControllerWithValidDiscussionIdWhenGettingCommentsAsCollaboratorShouldReturnHttpOkTest()
+                    throws Exception {
+
+        val discussion = projectRepository.findByTitle("Django").get().getDiscussions().get(0);
+
+        String contentAsString =
+                mvc.perform(
+                                MockMvcRequestBuilders.get(
+                                                baseUrl + "/comments/" + discussion.getId())
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        val comments = objectMapper.readValue(contentAsString, CommentDTO[].class);
+
+        assertNotNull(comments);
+        assertEquals(3, comments.length);
+    }
+
+    @Test
+    @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
+    void Test0035_ProjectControllerWhenReceivesValidUpdateDiscussionDTOshouldReturnOK()
             throws Exception {
 
         val project = projectRepository.findByTitle("Renovate");
@@ -800,7 +1016,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
     void
-            Test0039_ProjectControllerWhenReceivesValidUpdateDiscussionDTOButNotFromOwnerShouldReturnUnauthorized()
+            Test0036_ProjectControllerWhenReceivesValidUpdateDiscussionDTOButNotFromOwnerShouldReturnUnauthorized()
                     throws Exception {
         List<String> discussionTags = Arrays.asList("desctag1", "desctag2");
         DiscussionUpdateDTO discussionUpdateDTO =
@@ -832,7 +1048,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
     void
-            Test0040_ProjectControllerWhenReceivesValidUpdateDiscussionDTOButNotFromOwnerShouldReturnUnauthorized()
+            Test0037_ProjectControllerWhenReceivesValidUpdateDiscussionDTOButNotFromOwnerShouldReturnUnauthorized()
                     throws Exception {
         List<String> discussionTags = Arrays.asList("desctag1", "desctag2");
         DiscussionUpdateDTO discussionUpdateDTO =

--- a/src/test/java/com/a2/backend/controller/ProjectControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/ProjectControllerActiveTest.java
@@ -724,7 +724,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
 
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
-    void Test0038_ProjectControllerWhenReceivesValidUpdateDiscussionDTOshouldReturnOK()
+    void Test026_ProjectControllerWhenReceivesValidUpdateDiscussionDTOshouldReturnOK()
             throws Exception {
 
         val project = projectRepository.findByTitle("Renovate");
@@ -800,7 +800,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
     void
-            Test0039_ProjectControllerWhenReceivesValidUpdateDiscussionDTOButNotFromOwnerShouldReturnUnauthorized()
+            Test027_ProjectControllerWhenReceivesValidUpdateDiscussionDTOButNotFromOwnerShouldReturnUnauthorized()
                     throws Exception {
         List<String> discussionTags = Arrays.asList("desctag1", "desctag2");
         DiscussionUpdateDTO discussionUpdateDTO =
@@ -832,7 +832,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
     void
-            Test0040_ProjectControllerWhenReceivesValidUpdateDiscussionDTOButNotFromOwnerShouldReturnUnauthorized()
+            Test028_ProjectControllerWhenReceivesValidUpdateDiscussionDTOButNotFromOwnerShouldReturnUnauthorized()
                     throws Exception {
         List<String> discussionTags = Arrays.asList("desctag1", "desctag2");
         DiscussionUpdateDTO discussionUpdateDTO =

--- a/src/test/java/com/a2/backend/repository/DiscussionRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/DiscussionRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.a2.backend.BackendApplication;
 import com.a2.backend.entity.*;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import lombok.val;
@@ -27,6 +28,8 @@ public class DiscussionRepositoryTest {
     @Autowired private ProjectRepository projectRepository;
 
     @Autowired private UserRepository userRepository;
+
+    @Autowired private CommentRepository commentRepository;
 
     @Autowired private DiscussionRepository discussionRepository;
     String title = "New project";
@@ -54,12 +57,21 @@ public class DiscussionRepositoryTest {
                     .reviews(List.of())
                     .build();
 
+    Comment comment =
+            Comment.builder()
+                    .comment("Discussion comment")
+                    .user(owner)
+                    .date(LocalDateTime.now())
+                    .highlighted(false)
+                    .hidden(false)
+                    .build();
+
     Discussion discussion =
             Discussion.builder()
                     .title("Discussion")
                     .project(project)
                     .forumTags(forumTags)
-                    .comments(List.of())
+                    .comments(List.of(comment))
                     .build();
 
     @Test
@@ -158,6 +170,40 @@ public class DiscussionRepositoryTest {
         discussionRepository.save(discussion);
         Discussion savedDiscussion =
                 discussionRepository.findByProjectIdAndTitle(savedProject.getId(), "NotDiscussion");
+    }
+
+    @Test
+    void Test003_DiscussionRepositoryShouldGetDiscussionByCommentId() {
+        userRepository.save(owner);
+
+        assertTrue(projectRepository.findAll().isEmpty());
+
+        assertNull(project.getId());
+        assertEquals(project.getTitle(), title);
+        assertEquals(project.getDescription(), description);
+        assertEquals(project.getOwner(), owner);
+
+        projectRepository.save(project);
+
+        assertFalse(projectRepository.findAll().isEmpty());
+
+        List<Project> projects = projectRepository.findAll();
+
+        assertEquals(1, projects.size());
+
+        val savedProject = projects.get(0);
+
+        assertNotNull(savedProject.getId());
+        assertEquals(savedProject.getTitle(), title);
+        assertEquals(savedProject.getDescription(), description);
+        assertEquals(savedProject.getOwner(), owner);
+
+        val savedDiscussion = discussionRepository.save(discussion);
+
+        val discussion = discussionRepository.findDiscussionByCommentId(comment.getId());
+
+        assertNotNull(discussion);
+        assertEquals(savedDiscussion.getId(), discussion.get().getId());
     }
 
     @Test

--- a/src/test/java/com/a2/backend/service/impl/CommentServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/CommentServiceActiveTest.java
@@ -1,12 +1,15 @@
 package com.a2.backend.service.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.a2.backend.entity.Comment;
+import com.a2.backend.exception.CommentNotFoundException;
 import com.a2.backend.model.CommentCreateDTO;
+import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.service.CommentService;
 import com.a2.backend.service.UserService;
+import java.util.UUID;
+import lombok.val;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -16,6 +19,8 @@ public class CommentServiceActiveTest extends AbstractServiceTest {
     @Autowired private UserService userService;
 
     @Autowired private CommentService commentService;
+
+    @Autowired private ProjectRepository projectRepository;
 
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
@@ -27,5 +32,161 @@ public class CommentServiceActiveTest extends AbstractServiceTest {
         assertEquals("comment", comment.getComment());
         assertNotNull(comment.getDate());
         assertEquals(userService.getLoggedUser(), comment.getUser());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test002_CommentServiceWhenReceiveNotValidCommentIdToHighlightShouldThrowException() {
+        assertThrows(
+                CommentNotFoundException.class,
+                () -> commentService.changeHighlight(UUID.randomUUID()));
+    }
+
+    @Test
+    @WithMockUser("agustin.ayerza@ing.austral.edu.ar")
+    void Test003_CommentServiceWithHighlightedCommentWhenChangingHighlightShouldChangeToFalse() {
+        val comment =
+                projectRepository
+                        .findByTitle("Django")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(1);
+
+        assertTrue(comment.isHighlighted());
+
+        val updatedComment = commentService.changeHighlight(comment.getId());
+
+        assertNotNull(updatedComment);
+        assertEquals(updatedComment.getId(), comment.getId());
+        assertFalse(comment.isHighlighted());
+        assertEquals(comment.isHidden(), updatedComment.isHidden());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test004_CommentServiceWithNotHighlightedCommentWhenChangingHighlightShouldChangeToTrueAndChangeHiddenWhenTrue() {
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(1);
+
+        assertFalse(comment.isHighlighted());
+        assertTrue(comment.isHidden());
+
+        val updatedComment = commentService.changeHighlight(comment.getId());
+
+        assertNotNull(updatedComment);
+        assertEquals(updatedComment.getId(), comment.getId());
+        assertTrue(comment.isHighlighted());
+        assertFalse(comment.isHidden());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test005_CommentServiceWithNotHighlightedCommentWhenChangingHighlightShouldChangeToTrueAndDontChangeHiddenWhenFalse() {
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(0);
+
+        assertFalse(comment.isHighlighted());
+        assertFalse(comment.isHidden());
+
+        val updatedComment = commentService.changeHighlight(comment.getId());
+
+        assertNotNull(updatedComment);
+        assertEquals(updatedComment.getId(), comment.getId());
+        assertTrue(comment.isHighlighted());
+        assertFalse(comment.isHidden());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test006_CommentServiceWhenReceiveNotValidCommentIdToHideShouldThrowException() {
+        assertThrows(
+                CommentNotFoundException.class,
+                () -> commentService.changeHidden(UUID.randomUUID()));
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test007_CommentServiceWithHiddenCommentWhenChangingHiddenShouldChangeToFalse() {
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(1);
+
+        assertTrue(comment.isHidden());
+
+        val updatedComment = commentService.changeHidden(comment.getId());
+
+        assertNotNull(updatedComment);
+        assertEquals(updatedComment.getId(), comment.getId());
+        assertFalse(comment.isHidden());
+        assertEquals(comment.isHighlighted(), updatedComment.isHighlighted());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test008_CommentServiceWithNotHiddenCommentWhenChangingHiddenShouldChangeToTrueAndChangeHighlightedWhenTrue() {
+        val comment =
+                projectRepository
+                        .findByTitle("Django")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(1);
+
+        assertFalse(comment.isHidden());
+        assertTrue(comment.isHighlighted());
+
+        val updatedComment = commentService.changeHidden(comment.getId());
+
+        assertNotNull(updatedComment);
+        assertEquals(updatedComment.getId(), comment.getId());
+        assertFalse(comment.isHighlighted());
+        assertTrue(comment.isHidden());
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void
+            Test009_CommentServiceWithNotHiddenCommentWhenChangingHiddenShouldChangeToTrueAndDontChangeHighlightWhenFalse() {
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(0);
+
+        assertFalse(comment.isHighlighted());
+        assertFalse(comment.isHidden());
+
+        val updatedComment = commentService.changeHidden(comment.getId());
+
+        assertNotNull(updatedComment);
+        assertEquals(updatedComment.getId(), comment.getId());
+        assertFalse(comment.isHighlighted());
+        assertTrue(comment.isHidden());
     }
 }

--- a/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
@@ -101,7 +101,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
     }
 
     @Test
-    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    @WithMockUser("franz.sotoleal@ing.austral.edu.ar")
     void Test006_GivenAWrongOwnerWhenWantToDeleteADiscussionThenThrowException() {
         Discussion discussion =
                 projectRepository.findByTitle("Django").get().getDiscussions().get(0);
@@ -109,6 +109,18 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
         assertThrows(
                 UserIsNotOwnerException.class,
                 () -> discussionService.deleteDiscussion(discussion.getId()));
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test007_GivenProjectOwnerWhenWantToDeleteADiscussionInHisProjectThenDeleteThatProject() {
+
+        assertEquals(2, projectRepository.findByTitle("Kubernetes").get().getDiscussions().size());
+        Discussion discussion =
+                projectRepository.findByTitle("Kubernetes").get().getDiscussions().get(0);
+        assertNotNull(discussion);
+        discussionService.deleteDiscussion(discussion.getId());
+        assertEquals(1, projectRepository.findByTitle("Kubernetes").get().getDiscussions().size());
     }
 
     @Test

--- a/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
@@ -126,7 +126,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
     void
-            Test005_DiscussionServiceWithInvalidCommentIdWhenHighlightingCommentShouldThrowException() {
+            Test008_DiscussionServiceWithInvalidCommentIdWhenHighlightingCommentShouldThrowException() {
         assertThrows(
                 DiscussionNotFoundException.class,
                 () -> discussionService.changeCommentHighlight(UUID.randomUUID()));
@@ -135,7 +135,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
     @Test
     @WithMockUser("agustin.ayerza@ing.austral.edu.ar")
     void
-            Test006_DiscussionServiceWithValidCommentIdButNotProjectOwnerWhenHighlightingCommentShouldThrowException() {
+            Test009_DiscussionServiceWithValidCommentIdButNotProjectOwnerWhenHighlightingCommentShouldThrowException() {
 
         val comment =
                 projectRepository
@@ -153,7 +153,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
 
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
-    void Test007_DiscussionServiceWithValidCommentIdWhenHighlightingCommentShouldUpdateComment() {
+    void Test010_DiscussionServiceWithValidCommentIdWhenHighlightingCommentShouldUpdateComment() {
 
         val comment =
                 projectRepository
@@ -175,7 +175,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
 
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
-    void Test008_DiscussionServiceWithInvalidCommentIdWhenHidingCommentShouldThrowException() {
+    void Test011_DiscussionServiceWithInvalidCommentIdWhenHidingCommentShouldThrowException() {
         assertThrows(
                 DiscussionNotFoundException.class,
                 () -> discussionService.changeCommentHidden(UUID.randomUUID()));
@@ -184,7 +184,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
     @Test
     @WithMockUser("agustin.ayerza@ing.austral.edu.ar")
     void
-            Test009_DiscussionServiceWithValidCommentIdButNotProjectOwnerWhenHidingCommentShouldThrowException() {
+            Test012_DiscussionServiceWithValidCommentIdButNotProjectOwnerWhenHidingCommentShouldThrowException() {
 
         val comment =
                 projectRepository
@@ -202,7 +202,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
 
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
-    void Test010_DiscussionServiceWithValidCommentIdWhenHidingCommentShouldUpdateComment() {
+    void Test013_DiscussionServiceWithValidCommentIdWhenHidingCommentShouldUpdateComment() {
 
         val comment =
                 projectRepository
@@ -225,7 +225,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
     @Test
     @WithMockUser("agustin.ayerza@ing.austral.edu.ar")
     void
-            Test011_DiscussionServiceWithNotValidDiscussionIdWhenGettingCommentsShouldThrowException() {
+            Test014_DiscussionServiceWithNotValidDiscussionIdWhenGettingCommentsShouldThrowException() {
 
         assertThrows(
                 DiscussionNotFoundException.class,
@@ -235,7 +235,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
     void
-            Test012_DiscussionServiceWithValidCommentIdWhenGettingCommentsAsOwnerShouldReturnListWithAllComments() {
+            Test015_DiscussionServiceWithValidCommentIdWhenGettingCommentsAsOwnerShouldReturnListWithAllComments() {
 
         val discussion = projectRepository.findByTitle("Kubernetes").get().getDiscussions().get(0);
 
@@ -249,7 +249,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
     @Test
     @WithMockUser("agustin.ayerza@ing.austral.edu.ar")
     void
-            Test013_DiscussionServiceWithValidCommentIdWhenGettingCommentsAsCollaboratorShouldReturnListWithFilteredComments() {
+            Test016_DiscussionServiceWithValidCommentIdWhenGettingCommentsAsCollaboratorShouldReturnListWithFilteredComments() {
 
         val discussion = projectRepository.findByTitle("Kubernetes").get().getDiscussions().get(0);
 
@@ -262,7 +262,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
     void
-            Test014_DiscussionServiceWithValidCommentIdWhenGettingCommentsAsCollaboratorShouldReturnFilteredCommentListInOrder() {
+            Test017_DiscussionServiceWithValidCommentIdWhenGettingCommentsAsCollaboratorShouldReturnFilteredCommentListInOrder() {
 
         val discussion = projectRepository.findByTitle("Django").get().getDiscussions().get(0);
 

--- a/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
@@ -100,7 +100,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
     }
 
     @Test
-    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    @WithMockUser("franz.sotoleal@ing.austral.edu.ar")
     void Test006_GivenAWrongOwnerWhenWantToDeleteADiscussionThenThrowException() {
         Discussion discussion =
                 projectRepository.findByTitle("Django").get().getDiscussions().get(0);
@@ -108,5 +108,17 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
         assertThrows(
                 UserIsNotOwnerException.class,
                 () -> discussionService.deleteDiscussion(discussion.getId()));
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test007_GivenProjectOwnerWhenWantToDeleteADiscussionInHisProjectThenDeleteThatProject() {
+
+        assertEquals(2, projectRepository.findByTitle("Kubernetes").get().getDiscussions().size());
+        Discussion discussion =
+                projectRepository.findByTitle("Kubernetes").get().getDiscussions().get(0);
+        assertNotNull(discussion);
+        discussionService.deleteDiscussion(discussion.getId());
+        assertEquals(1, projectRepository.findByTitle("Kubernetes").get().getDiscussions().size());
     }
 }


### PR DESCRIPTION
Como usuario dueño de proyecto quiero poder dar de baja discusiones sobre mi proyecto de forma de no perder control sobre las cosas que se muestran relacionadas con mi proyecto

UAT

- Desde la pantalla de administración de discusiones se debe poder eliminar a todos las discusiones disponibles siempre y cuando el usuario logueado sea el dueño del proyecto
- desde la página de listado de discusiones las discusiones iniciadas por el usuario deben aparecer con un botón para borrar
- cuando este botón se toca aparece un pop up que confirma que el usuario quiere eliminar la discusión 
- Si se confirma la baja se muestra un mensaje que avisa que se eliminó correctamente
- Ante un error se debe mostrar un mensaje de error
