### PR TITLE
Us 5.3.6/modificacion comentario de discusion

### DIFF
--- a/src/main/java/com/a2/backend/DemoRunner.java
+++ b/src/main/java/com/a2/backend/DemoRunner.java
@@ -372,8 +372,7 @@ public class DemoRunner implements CommandLineRunner {
                                 .forumTags(List.of(forumTagRepository.findByName("help").get()))
                                 .project(tensorFlow)
                                 .comments(List.of())
-                                .body(
-                                        "I am having this bug with in my code. How  do I fix it?")
+                                .body("I am having this bug with in my code. How  do I fix it?")
                                 .build()));
         django.setDiscussions(
                 List.of(
@@ -385,8 +384,7 @@ public class DemoRunner implements CommandLineRunner {
                                                 forumTagRepository.findByName("advice").get()))
                                 .project(django)
                                 .owner(peltevis)
-                                .body(
-                                        "I am having this problem with viewset. How  do I fix it?")
+                                .body("I am having this problem with viewset. How  do I fix it?")
                                 .comments(
                                         List.of(
                                                 Comment.builder()
@@ -425,8 +423,7 @@ public class DemoRunner implements CommandLineRunner {
         kubernetes.setDiscussions(
                 List.of(
                         Discussion.builder()
-                                .body(
-                                        "How do I make Kubernetes work on MacOS")
+                                .body("How do I make Kubernetes work on MacOS")
                                 .title("Not working on MacOS")
                                 .forumTags(List.of(forumTagRepository.findByName("help").get()))
                                 .project(kubernetes)
@@ -449,8 +446,7 @@ public class DemoRunner implements CommandLineRunner {
                                                         .build()))
                                 .build(),
                         Discussion.builder()
-                                .body(
-                                        "How do I fix this bug")
+                                .body("How do I fix this bug")
                                 .title("Bug US-5.4")
                                 .forumTags(List.of(forumTagRepository.findByName("advice").get()))
                                 .project(kubernetes)

--- a/src/main/java/com/a2/backend/controller/DiscussionController.java
+++ b/src/main/java/com/a2/backend/controller/DiscussionController.java
@@ -1,8 +1,8 @@
 package com.a2.backend.controller;
 
 import com.a2.backend.constants.SecurityConstants;
-import com.a2.backend.model.CommentUpdateDTO;
 import com.a2.backend.model.CommentCreateDTO;
+import com.a2.backend.model.CommentUpdateDTO;
 import com.a2.backend.model.DiscussionUpdateDTO;
 import com.a2.backend.service.DiscussionService;
 import java.util.UUID;

--- a/src/main/java/com/a2/backend/controller/DiscussionController.java
+++ b/src/main/java/com/a2/backend/controller/DiscussionController.java
@@ -1,6 +1,7 @@
 package com.a2.backend.controller;
 
 import com.a2.backend.constants.SecurityConstants;
+import com.a2.backend.model.CommentUpdateDTO;
 import com.a2.backend.model.CommentCreateDTO;
 import com.a2.backend.model.DiscussionUpdateDTO;
 import com.a2.backend.service.DiscussionService;
@@ -71,5 +72,13 @@ public class DiscussionController {
     public ResponseEntity<?> deleteComment(@PathVariable UUID id) {
         discussionService.deleteComment(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @PutMapping("/comment-update/{commentId}")
+    public ResponseEntity<?> updateComment(
+            @PathVariable UUID commentId, @Valid @RequestBody CommentUpdateDTO commentUpdateDTO) {
+        val comment = discussionService.updateComment(commentId, commentUpdateDTO);
+        return ResponseEntity.status(HttpStatus.OK).body(comment);
     }
 }

--- a/src/main/java/com/a2/backend/model/CommentUpdateDTO.java
+++ b/src/main/java/com/a2/backend/model/CommentUpdateDTO.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CommentCreateDTO {
+public class CommentUpdateDTO {
 
     @NotBlank(message = "Comment cannot be empty")
     @Size(max = 500, message = "Comment should have less than 500 characters")

--- a/src/main/java/com/a2/backend/service/CommentService.java
+++ b/src/main/java/com/a2/backend/service/CommentService.java
@@ -2,6 +2,7 @@ package com.a2.backend.service;
 
 import com.a2.backend.entity.Comment;
 import com.a2.backend.model.CommentCreateDTO;
+import com.a2.backend.model.CommentUpdateDTO;
 import java.util.UUID;
 
 public interface CommentService {
@@ -13,4 +14,6 @@ public interface CommentService {
     Comment changeHidden(UUID commentId);
 
     Comment deleteComment(UUID id);
+
+    Comment updateComment(UUID commentId, CommentUpdateDTO commentUpdateDTO);
 }

--- a/src/main/java/com/a2/backend/service/DiscussionService.java
+++ b/src/main/java/com/a2/backend/service/DiscussionService.java
@@ -23,4 +23,6 @@ public interface DiscussionService {
     List<CommentDTO> getComments(UUID discussionId);
 
     void deleteComment(UUID id);
+
+    CommentDTO updateComment(UUID commentId, CommentUpdateDTO commentUpdateDTO);
 }

--- a/src/main/java/com/a2/backend/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/CommentServiceImpl.java
@@ -5,6 +5,7 @@ import com.a2.backend.entity.User;
 import com.a2.backend.exception.CommentNotFoundException;
 import com.a2.backend.exception.InvalidUserException;
 import com.a2.backend.model.CommentCreateDTO;
+import com.a2.backend.model.CommentUpdateDTO;
 import com.a2.backend.repository.CommentRepository;
 import com.a2.backend.service.CommentService;
 import com.a2.backend.service.UserService;
@@ -86,6 +87,27 @@ public class CommentServiceImpl implements CommentService {
         if (!comment.getUser().equals(loggedUser))
             throw new InvalidUserException("Only comment owners can delete comments");
         commentRepository.deleteById(id);
+        return comment;
+    }
+
+    @Override
+    public Comment updateComment(UUID commentId, CommentUpdateDTO commentUpdateDTO) {
+        User loggedUser = userService.getLoggedUser();
+        val commentOptional = commentRepository.findById(commentId);
+
+        if (commentOptional.isEmpty()) {
+            throw new CommentNotFoundException(
+                    String.format("Comment with id: %s not found", commentId));
+        }
+
+        val comment = commentOptional.get();
+
+        if (!comment.getUser().equals(loggedUser)) {
+            throw new InvalidUserException("Only comment creator can update comment");
+        }
+
+        comment.setComment(commentUpdateDTO.getComment());
+
         return comment;
     }
 }

--- a/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
@@ -298,4 +298,25 @@ public class DiscussionServiceImpl implements DiscussionService {
 
         discussionRepository.save(discussion);
     }
+
+    @Override
+    public CommentDTO updateComment(UUID commentId, CommentUpdateDTO commentUpdateDTO) {
+        val discussionOptional = discussionRepository.findDiscussionByCommentId(commentId);
+
+        if (discussionOptional.isEmpty()) {
+            throw new DiscussionNotFoundException(
+                    String.format("Discussion with comment id: %s not found", commentId));
+        }
+
+        val discussion = discussionOptional.get();
+
+        val comments = discussionOptional.get().getComments();
+
+        val updatedComment = commentService.updateComment(commentId, commentUpdateDTO);
+
+        discussion.setComments(comments);
+        discussionRepository.save(discussion);
+
+        return updatedComment.toDTO();
+    }
 }

--- a/src/test/java/com/a2/backend/controller/DiscussionControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/DiscussionControllerActiveTest.java
@@ -532,8 +532,8 @@ class DiscussionControllerActiveTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
     void
-    Test001_ProjectControllerWithValidCommentIdAndCommentUpdateDTOWhenUpdatingShouldReturnHttpOkTest()
-            throws Exception {
+            Test019_DiscussionControllerWithValidCommentIdAndCommentUpdateDTOWhenUpdatingShouldReturnHttpOkTest()
+                    throws Exception {
 
         val comment =
                 projectRepository
@@ -568,8 +568,8 @@ class DiscussionControllerActiveTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
     void
-    Test002_ProjectControllerWithValidCommentIdAndBlankCommentUpdateDTOWhenUpdatingShouldReturnBadRequest()
-            throws Exception {
+            Test020_DiscussionControllerWithValidCommentIdAndBlankCommentUpdateDTOWhenUpdatingShouldReturnBadRequest()
+                    throws Exception {
 
         val comment =
                 projectRepository
@@ -600,7 +600,7 @@ class DiscussionControllerActiveTest extends AbstractControllerTest {
 
     @Test
     @WithMockUser(username = "rodrigo.pazos@ing.austral.edu.ar")
-    void Test003_ProjectControllerWithNotValidCommentIdWhenUpdatingShouldReturnBadRequest()
+    void Test021_DiscussionControllerWithNotValidCommentIdWhenUpdatingShouldReturnBadRequest()
             throws Exception {
 
         val comment =
@@ -633,8 +633,8 @@ class DiscussionControllerActiveTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
     void
-    Test004_ProjectControllerWithValidCommentIdAndCommentUpdateDTOButLoggedUserIsNotCreatorWhenUpdatingShouldReturnBadRequest()
-            throws Exception {
+            Test022_DiscussionControllerWithValidCommentIdAndCommentUpdateDTOButLoggedUserIsNotCreatorWhenUpdatingShouldReturnBadRequest()
+                    throws Exception {
 
         val comment =
                 projectRepository

--- a/src/test/java/com/a2/backend/controller/ProjectControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/ProjectControllerActiveTest.java
@@ -645,7 +645,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     // Search projects by title only with value "KaI" should return only Sakai project
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0041_ProjectSearch() throws Exception {
+    void Test0023_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch = ProjectSearchDTO.builder().title("KaI").build();
         String contentAsString =
                 mvc.perform(
@@ -669,7 +669,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
      */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0042_ProjectSearch() throws Exception {
+    void Test0024_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder().title("KuBER").featured(true).build();
         String contentAsString =
@@ -693,7 +693,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
      */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0043_ProjectSearch() throws Exception {
+    void Test0025_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder().languages(Arrays.asList("Java")).build();
         String contentAsString =
@@ -723,7 +723,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
      */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0044_ProjectSearch() throws Exception {
+    void Test0026_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder().languages(Arrays.asList("java")).build();
         String contentAsString =
@@ -750,7 +750,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     /** Search projects only by languages with value Jav should return empty project list */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0045_ProjectSearch() throws Exception {
+    void Test0027_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder().languages(Arrays.asList("Jav")).build();
         String contentAsString =
@@ -772,7 +772,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     /** Search projects only by languages with value Java and should return empty project list */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0046_ProjectSearch() throws Exception {
+    void Test0028_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder().languages(Arrays.asList("Jav")).build();
         String contentAsString =
@@ -797,7 +797,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
      */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0047_ProjectSearch() throws Exception {
+    void Test0029_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder().languages(Arrays.asList("java", "javascript")).build();
         String contentAsString =
@@ -822,7 +822,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
      */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0048_ProjectSearch() throws Exception {
+    void Test0030_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder().tags(Arrays.asList("tOol")).build();
         String contentAsString =
@@ -848,7 +848,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     /** Search projects only by tags with value tOo should return empty project list */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0049_ProjectSearch() throws Exception {
+    void Test0031_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder().tags(Arrays.asList("tOo")).build();
         String contentAsString =
@@ -870,7 +870,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     /** Search projects only by tags with value tOol and automation should return project ansible */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0050_ProjectSearch() throws Exception {
+    void Test0032_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder().tags(Arrays.asList("tOol", "automation")).build();
         String contentAsString =
@@ -898,7 +898,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
      */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0051_ProjectSearch() throws Exception {
+    void Test0033_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder()
                         .tags(Arrays.asList("big data"))
@@ -926,7 +926,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
      */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0052_ProjectSearch() throws Exception {
+    void Test0034_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder()
                         .tags(Arrays.asList("big data"))
@@ -954,7 +954,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
      */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0053_ProjectSearch() throws Exception {
+    void Test0035_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder()
                         .tags(Arrays.asList("dependency"))
@@ -987,7 +987,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
      */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0054_ProjectSearch() throws Exception {
+    void Test0036_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder()
                         .tags(Arrays.asList("dependency"))
@@ -1015,7 +1015,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
      */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0055_ProjectSearch() throws Exception {
+    void Test0037_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder()
                         .tags(Arrays.asList("dependency"))
@@ -1044,7 +1044,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
      */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0056_ProjectSearch() throws Exception {
+    void Test0038_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder()
                         .tags(Arrays.asList("tool"))
@@ -1070,7 +1070,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     /** Search all project with page value 1 should return 3 projects */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0057_ProjectSearch() throws Exception {
+    void Test0039_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch = ProjectSearchDTO.builder().page(1).build();
         String contentAsString =
                 mvc.perform(
@@ -1091,7 +1091,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     /** Search all project with page value 0 should return 8 projects */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0058_ProjectSearch() throws Exception {
+    void Test0040_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch = ProjectSearchDTO.builder().page(0).build();
         String contentAsString =
                 mvc.perform(
@@ -1112,7 +1112,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     /** Search all featured project with page value 1 should return 0 projects */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0059_ProjectSearch() throws Exception {
+    void Test0041_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder().featured(true).page(1).build();
         String contentAsString =
@@ -1132,7 +1132,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     /** Test pagination when searching for featured projects */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0060_ProjectSearch() throws Exception {
+    void Test0042_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch =
                 ProjectSearchDTO.builder().featured(true).page(0).build();
         String contentAsString =
@@ -1152,7 +1152,7 @@ public class ProjectControllerActiveTest extends AbstractControllerTest {
     /** search for featured projects should return four projects */
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test0061_ProjectSearch() throws Exception {
+    void Test0043_ProjectSearch() throws Exception {
         ProjectSearchDTO projectToSearch = ProjectSearchDTO.builder().featured(true).build();
         String contentAsString =
                 mvc.perform(

--- a/src/test/java/com/a2/backend/repository/DiscussionRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/DiscussionRepositoryTest.java
@@ -174,7 +174,7 @@ public class DiscussionRepositoryTest {
     }
 
     @Test
-    void Test003_DiscussionRepositoryShouldGetDiscussionByCommentId() {
+    void Test004_DiscussionRepositoryShouldGetDiscussionByCommentId() {
         userRepository.save(owner);
 
         assertTrue(projectRepository.findAll().isEmpty());

--- a/src/test/java/com/a2/backend/repository/ProjectRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/ProjectRepositoryTest.java
@@ -230,7 +230,7 @@ class ProjectRepositoryTest {
 
     @Test
     void
-            Test007_ProjectRepositoryWhenGivenLanguageNameShouldReturnAllProjectsThatHaveThatLanguage() {
+            Test008_ProjectRepositoryWhenGivenLanguageNameShouldReturnAllProjectsThatHaveThatLanguage() {
         userRepository.save(owner);
 
         Tag tag1 = Tag.builder().name("tag1").build();
@@ -296,7 +296,7 @@ class ProjectRepositoryTest {
     }
 
     @Test
-    public void Test008_GivenTitleFilterSearchisSuccesfull() {
+    public void Test009_GivenTitleFilterSearchisSuccesfull() {
         Tag tag1 = Tag.builder().name("tag1").build();
         Tag tag2 = Tag.builder().name("tag2").build();
         Tag tag3 = Tag.builder().name("tag3").build();

--- a/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
@@ -8,6 +8,7 @@ import com.a2.backend.exception.DiscussionNotFoundException;
 import com.a2.backend.exception.InvalidUserException;
 import com.a2.backend.exception.UserIsNotOwnerException;
 import com.a2.backend.model.CommentCreateDTO;
+import com.a2.backend.model.CommentUpdateDTO;
 import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.service.DiscussionService;
 import java.util.List;
@@ -315,5 +316,26 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
         assertThrows(
                 InvalidUserException.class,
                 () -> discussionService.deleteComment(discussion.getComments().get(0).getId()));
+    }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test014_DiscussionServiceWithValidCommentIdWhenUpdatingShouldReturnUpdatedComment() {
+
+        val comment =
+                projectRepository
+                        .findByTitle("Kubernetes")
+                        .get()
+                        .getDiscussions()
+                        .get(0)
+                        .getComments()
+                        .get(1);
+
+        CommentUpdateDTO commentUpdateDTO =
+                CommentUpdateDTO.builder().comment("updated comment").build();
+
+        assertEquals("Or maybe just a reboot first...", comment.getComment());
+        discussionService.updateComment(comment.getId(), commentUpdateDTO);
+        assertEquals("updated comment", comment.getComment());
     }
 }

--- a/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/DiscussionServiceActiveTest.java
@@ -320,7 +320,7 @@ public class DiscussionServiceActiveTest extends AbstractServiceTest {
 
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
-    void Test014_DiscussionServiceWithValidCommentIdWhenUpdatingShouldReturnUpdatedComment() {
+    void Test021_DiscussionServiceWithValidCommentIdWhenUpdatingShouldReturnUpdatedComment() {
 
         val comment =
                 projectRepository


### PR DESCRIPTION
Como usuario owner o colaborador quiero poder modificar mis comentarios sobre discusiones para poder corregirlos

UAT

Se debe mostrar una opcion para modificar mis comentarios sobre el mismo comentario. Esta opcion solo debe existir para los comentarios creados por el usuario
Cuando se selecciona este boton debe aparecer un pop up con un espacio para modificar el texto que debe tener al texto del comentario como existe hasta ese momento.
Debe haber un boton para cancelar la operacion que cierra el pop up
Debe haber un boton para actualizar el comentario.
Cuando el comentario se actualiza correctamente se muestra un mensaje que confirma que se actualizo correctamente