### PR TITLE
Added feature listado de notificaciones

### DIFF
--- a/src/main/java/com/a2/backend/DemoRunner.java
+++ b/src/main/java/com/a2/backend/DemoRunner.java
@@ -1,6 +1,7 @@
 package com.a2.backend;
 
 import com.a2.backend.annotation.Generated;
+import com.a2.backend.constants.NotificationType;
 import com.a2.backend.constants.PrivacyConstant;
 import com.a2.backend.entity.*;
 import com.a2.backend.repository.*;
@@ -30,6 +31,7 @@ public class DemoRunner implements CommandLineRunner {
     @Autowired private TagRepository tagRepository;
     @Autowired private ForumTagRepository forumTagRepository;
     @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private NotificationRepository notificationRepository;
 
     public DemoRunner() {}
 
@@ -50,6 +52,7 @@ public class DemoRunner implements CommandLineRunner {
         loadUsers();
         loadForumTags();
         loadProjects();
+        loadNotifications();
         logger.info("Created demo data");
     }
 
@@ -63,6 +66,10 @@ public class DemoRunner implements CommandLineRunner {
 
     public void setProjectRepository(ProjectRepository projectRepository) {
         this.projectRepository = projectRepository;
+    }
+
+    public void setNotificationRepository(NotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
     }
 
     private void loadUsers() {
@@ -540,6 +547,151 @@ public class DemoRunner implements CommandLineRunner {
         forumTagRepository.save(helpPlease);
         forumTagRepository.save(softwareLib);
         forumTagRepository.save(great);
+    }
+
+    private void loadNotifications() {
+        User peltevis = userRepository.findByNickname("Peltevis").get();
+        User fabriDS23 = userRepository.findByNickname("FabriDS23").get();
+        User ropa1998 = userRepository.findByNickname("ropa1998").get();
+        User franz = userRepository.findByNickname("Franz").get();
+
+        Project tensorFlow = projectRepository.findByTitle("TensorFlow").get();
+        Project django = projectRepository.findByTitle("Django").get();
+        Project node = projectRepository.findByTitle("Node.js").get();
+        Project kubernetes = projectRepository.findByTitle("Kubernetes").get();
+
+        // applicant notifications
+        Notification notif1 =
+                Notification.builder()
+                        .type(NotificationType.APPLICANT)
+                        .project(tensorFlow)
+                        .user(peltevis)
+                        .userToNotify(ropa1998)
+                        .date(LocalDateTime.now())
+                        .seen(true)
+                        .build();
+
+        Notification notif2 =
+                Notification.builder()
+                        .type(NotificationType.APPLICANT)
+                        .project(django)
+                        .user(fabriDS23)
+                        .userToNotify(peltevis)
+                        .date(LocalDateTime.now().plusNanos(3))
+                        .seen(true)
+                        .build();
+
+        // review notifications
+        Notification notif3 =
+                Notification.builder()
+                        .type(NotificationType.REVIEW)
+                        .project(django)
+                        .user(peltevis)
+                        .userToNotify(ropa1998)
+                        .date(LocalDateTime.now().plusNanos(3))
+                        .seen(false)
+                        .build();
+
+        Notification notif4 =
+                Notification.builder()
+                        .type(NotificationType.REVIEW)
+                        .project(node)
+                        .user(fabriDS23)
+                        .userToNotify(ropa1998)
+                        .date(LocalDateTime.now().plusNanos(3))
+                        .seen(false)
+                        .build();
+
+        Notification notif5 =
+                Notification.builder()
+                        .type(NotificationType.REVIEW)
+                        .project(node)
+                        .user(fabriDS23)
+                        .userToNotify(peltevis)
+                        .date(LocalDateTime.now().plusNanos(3))
+                        .seen(false)
+                        .build();
+
+        // discussion notifications
+        Notification notif6 =
+                Notification.builder()
+                        .type(NotificationType.DISCUSSION)
+                        .project(django)
+                        .discussion(django.getDiscussions().get(0))
+                        .user(peltevis)
+                        .userToNotify(ropa1998)
+                        .date(LocalDateTime.now().plusNanos(3))
+                        .seen(false)
+                        .build();
+
+        Notification notif7 =
+                Notification.builder()
+                        .type(NotificationType.DISCUSSION)
+                        .project(kubernetes)
+                        .discussion(kubernetes.getDiscussions().get(0))
+                        .user(franz)
+                        .userToNotify(peltevis)
+                        .date(LocalDateTime.now().plusNanos(3))
+                        .seen(false)
+                        .build();
+
+        Notification notif8 =
+                Notification.builder()
+                        .type(NotificationType.DISCUSSION)
+                        .project(kubernetes)
+                        .discussion(kubernetes.getDiscussions().get(0))
+                        .user(franz)
+                        .userToNotify(fabriDS23)
+                        .date(LocalDateTime.now().plusNanos(3))
+                        .seen(true)
+                        .build();
+        Notification notif9 =
+                Notification.builder()
+                        .type(NotificationType.DISCUSSION)
+                        .project(kubernetes)
+                        .discussion(kubernetes.getDiscussions().get(0))
+                        .user(franz)
+                        .userToNotify(ropa1998)
+                        .date(LocalDateTime.now().plusNanos(3))
+                        .seen(false)
+                        .build();
+
+        // comments notifications
+        Notification notif10 =
+                Notification.builder()
+                        .type(NotificationType.COMMENT)
+                        .project(kubernetes)
+                        .discussion(kubernetes.getDiscussions().get(0))
+                        .comment(kubernetes.getDiscussions().get(0).getComments().get(0))
+                        .user(franz)
+                        .userToNotify(ropa1998)
+                        .date(LocalDateTime.now().plusNanos(3))
+                        .seen(false)
+                        .build();
+
+        Notification notif11 =
+                Notification.builder()
+                        .type(NotificationType.COMMENT)
+                        .project(kubernetes)
+                        .discussion(kubernetes.getDiscussions().get(0))
+                        .comment(kubernetes.getDiscussions().get(0).getComments().get(0))
+                        .user(ropa1998)
+                        .userToNotify(franz)
+                        .date(LocalDateTime.now().plusNanos(3))
+                        .seen(false)
+                        .build();
+
+        notificationRepository.save(notif1);
+        notificationRepository.save(notif2);
+        notificationRepository.save(notif3);
+        notificationRepository.save(notif4);
+        notificationRepository.save(notif5);
+        notificationRepository.save(notif6);
+        notificationRepository.save(notif7);
+        notificationRepository.save(notif8);
+        notificationRepository.save(notif9);
+        notificationRepository.save(notif10);
+        notificationRepository.save(notif11);
     }
 
     @SafeVarargs

--- a/src/main/java/com/a2/backend/controller/NotificationController.java
+++ b/src/main/java/com/a2/backend/controller/NotificationController.java
@@ -1,0 +1,27 @@
+package com.a2.backend.controller;
+
+import com.a2.backend.constants.SecurityConstants;
+import com.a2.backend.service.NotificationService;
+import lombok.val;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/notification")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @GetMapping
+    public ResponseEntity<?> getNotificationsOfLoggedUser() {
+        val userNotifications = notificationService.getNotificationsOfLoggedUser();
+        return ResponseEntity.status(HttpStatus.OK).body(userNotifications);
+    }
+}

--- a/src/main/java/com/a2/backend/entity/Discussion.java
+++ b/src/main/java/com/a2/backend/entity/Discussion.java
@@ -2,17 +2,16 @@ package com.a2.backend.entity;
 
 import com.a2.backend.model.DiscussionDTO;
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import lombok.*;
-import org.hibernate.annotations.LazyCollection;
-import org.hibernate.annotations.LazyCollectionOption;
-
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
+import lombok.*;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 
 @Entity
 @Getter

--- a/src/main/java/com/a2/backend/entity/Notification.java
+++ b/src/main/java/com/a2/backend/entity/Notification.java
@@ -2,15 +2,11 @@ package com.a2.backend.entity;
 
 import com.a2.backend.constants.NotificationType;
 import com.a2.backend.model.NotificationDTO;
-import lombok.*;
-import org.hibernate.annotations.LazyCollection;
-import org.hibernate.annotations.LazyCollectionOption;
-
-import javax.persistence.*;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
-import java.util.List;
+import java.time.LocalDateTime;
 import java.util.UUID;
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import lombok.*;
 
 @Entity
 @Getter
@@ -26,40 +22,35 @@ public class Notification {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
 
-    @NotNull
-    private NotificationType type;
+    @NotNull private NotificationType type;
 
     // These are the users to be notified
-    @ManyToMany
-    @LazyCollection(LazyCollectionOption.FALSE)
-    @NotEmpty
-    private List<User> users;
+    @ManyToOne @NotNull private User userToNotify;
 
-    @ManyToOne
-    private Project project;
+    @ManyToOne private Project project;
 
-    @ManyToOne
-    private Discussion discussion;
+    @ManyToOne private Discussion discussion;
 
-    @ManyToOne
-    private Comment comment;
+    @ManyToOne private Comment comment;
 
     // This is a user related to the notification (e.g., "${user} wrote a discussion on ${project}")
-    @ManyToOne
-    private User user;
+    @ManyToOne private User user;
 
-    @NotNull
-    @Builder.Default
-    private boolean seen = false;
+    @NotNull @Builder.Default private boolean seen = false;
+
+    @NotNull private LocalDateTime date;
 
     public NotificationDTO toDTO() {
         return NotificationDTO.builder()
                 .id(id)
                 .type(type)
                 .user(user != null ? user.toDTO() : null)
+                .userToNotify(userToNotify.toDTO())
                 .project(project != null ? project.toDTO() : null)
                 .discussion(discussion != null ? discussion.toDTO() : null)
                 .comment(comment != null ? comment.toDTO() : null)
+                .date(date)
+                .seen(seen)
                 .build();
     }
 }

--- a/src/main/java/com/a2/backend/model/NotificationCreateDTO.java
+++ b/src/main/java/com/a2/backend/model/NotificationCreateDTO.java
@@ -5,11 +5,8 @@ import com.a2.backend.entity.Comment;
 import com.a2.backend.entity.Discussion;
 import com.a2.backend.entity.Project;
 import com.a2.backend.entity.User;
-import lombok.*;
-
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import java.util.List;
+import lombok.*;
 
 @Getter
 @Setter
@@ -19,11 +16,9 @@ import java.util.List;
 @AllArgsConstructor
 public class NotificationCreateDTO {
 
-    @NotNull
-    private NotificationType type;
+    @NotNull private NotificationType type;
 
-    @NotEmpty
-    private List<User> users;
+    @NotNull private User userToNotify;
 
     private Project project;
 

--- a/src/main/java/com/a2/backend/model/NotificationDTO.java
+++ b/src/main/java/com/a2/backend/model/NotificationDTO.java
@@ -1,10 +1,10 @@
 package com.a2.backend.model;
 
 import com.a2.backend.constants.NotificationType;
-import lombok.*;
-
-import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import java.util.UUID;
+import javax.validation.constraints.NotNull;
+import lombok.*;
 
 @Getter
 @Setter
@@ -16,8 +16,7 @@ public class NotificationDTO {
 
     private UUID id;
 
-    @NotNull
-    private NotificationType type;
+    @NotNull private NotificationType type;
 
     private ProjectDTO project;
 
@@ -26,6 +25,10 @@ public class NotificationDTO {
     private CommentDTO comment;
 
     private ProjectUserDTO user;
+
+    private ProjectUserDTO userToNotify;
+
+    private LocalDateTime date;
 
     private boolean seen;
 }

--- a/src/main/java/com/a2/backend/model/ProjectUpdateDTO.java
+++ b/src/main/java/com/a2/backend/model/ProjectUpdateDTO.java
@@ -1,13 +1,12 @@
 package com.a2.backend.model;
 
-import lombok.*;
-import org.hibernate.validator.constraints.UniqueElements;
-
+import java.util.List;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import java.util.List;
+import lombok.*;
+import org.hibernate.validator.constraints.UniqueElements;
 
 @Getter
 @Setter
@@ -51,11 +50,11 @@ public class ProjectUpdateDTO {
     @Size(min = 1, max = 5, message = "Number of ForumTags must be between 1 and 5")
     @UniqueElements
     private List<
-            @Pattern(regexp = "[a-zA-Z0-9 ]+")
-            @Size(
-                    min = 1,
-                    max = 24,
-                    message = "Tag name must be between 1 and 24 characters")
+                    @Pattern(regexp = "[a-zA-Z0-9 ]+")
+                    @Size(
+                            min = 1,
+                            max = 24,
+                            message = "Tag name must be between 1 and 24 characters")
                     String>
             forumTags;
 

--- a/src/main/java/com/a2/backend/repository/NotificationRepository.java
+++ b/src/main/java/com/a2/backend/repository/NotificationRepository.java
@@ -2,11 +2,11 @@ package com.a2.backend.repository;
 
 import com.a2.backend.entity.Notification;
 import com.a2.backend.entity.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
-    List<Notification> findAllByUsersContaining(User user);
+
+    List<Notification> findAllByUserToNotify(User userToNotify);
 }

--- a/src/main/java/com/a2/backend/service/NotificationService.java
+++ b/src/main/java/com/a2/backend/service/NotificationService.java
@@ -2,7 +2,10 @@ package com.a2.backend.service;
 
 import com.a2.backend.model.NotificationCreateDTO;
 import com.a2.backend.model.NotificationDTO;
+import java.util.List;
 
 public interface NotificationService {
     NotificationDTO createNotification(NotificationCreateDTO notificationCreateDTO);
+
+    List<NotificationDTO> getNotificationsOfLoggedUser();
 }

--- a/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/DiscussionServiceImpl.java
@@ -10,15 +10,14 @@ import com.a2.backend.model.*;
 import com.a2.backend.repository.DiscussionRepository;
 import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.service.*;
-import lombok.val;
-import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.transaction.Transactional;
+import lombok.val;
+import org.springframework.stereotype.Service;
 
 @Service
 public class DiscussionServiceImpl implements DiscussionService {
@@ -84,15 +83,17 @@ public class DiscussionServiceImpl implements DiscussionService {
             toNotify.remove(loggedUser);
             if (loggedUser != project.get().getOwner()) toNotify.add(project.get().getOwner());
             if (!toNotify.isEmpty()) {
-                NotificationCreateDTO notificationCreateDTO =
-                        NotificationCreateDTO.builder()
-                                .type(NotificationType.DISCUSSION)
-                                .discussion(discussion)
-                                .project(project.get())
-                                .user(loggedUser)
-                                .users(toNotify)
-                                .build();
-                notificationService.createNotification(notificationCreateDTO);
+                for (User userToNotify : toNotify) {
+                    NotificationCreateDTO notificationCreateDTO =
+                            NotificationCreateDTO.builder()
+                                    .type(NotificationType.DISCUSSION)
+                                    .discussion(discussion)
+                                    .project(project.get())
+                                    .user(loggedUser)
+                                    .userToNotify(userToNotify)
+                                    .build();
+                    notificationService.createNotification(notificationCreateDTO);
+                }
             }
             return createdDiscussion.toDTO();
         }
@@ -135,19 +136,21 @@ public class DiscussionServiceImpl implements DiscussionService {
             toNotify.add(discussion.getOwner());
 
         if (!toNotify.isEmpty()) {
-            NotificationCreateDTO notificationCreateDTO =
-                    NotificationCreateDTO.builder()
-                            .type(NotificationType.COMMENT)
-                            .comment(
-                                    discussion
-                                            .getComments()
-                                            .get(discussion.getComments().size() - 1))
-                            .discussion(discussion)
-                            .project(project)
-                            .user(loggedUser)
-                            .users(toNotify)
-                            .build();
-            notificationService.createNotification(notificationCreateDTO);
+            for (User userToNotify : toNotify) {
+                NotificationCreateDTO notificationCreateDTO =
+                        NotificationCreateDTO.builder()
+                                .type(NotificationType.COMMENT)
+                                .comment(
+                                        discussion
+                                                .getComments()
+                                                .get(discussion.getComments().size() - 1))
+                                .discussion(discussion)
+                                .project(project)
+                                .user(loggedUser)
+                                .userToNotify(userToNotify)
+                                .build();
+                notificationService.createNotification(notificationCreateDTO);
+            }
         }
 
         return comment.toDTO();

--- a/src/main/java/com/a2/backend/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/NotificationServiceImpl.java
@@ -1,32 +1,54 @@
 package com.a2.backend.service.impl;
 
 import com.a2.backend.entity.Notification;
+import com.a2.backend.entity.User;
 import com.a2.backend.model.NotificationCreateDTO;
 import com.a2.backend.model.NotificationDTO;
 import com.a2.backend.repository.NotificationRepository;
 import com.a2.backend.service.NotificationService;
+import com.a2.backend.service.UserService;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+import lombok.val;
 import org.springframework.stereotype.Service;
 
 @Service
 public class NotificationServiceImpl implements NotificationService {
 
-    NotificationRepository notificationRepository;
+    private final NotificationRepository notificationRepository;
+    private final UserService userService;
 
-    public NotificationServiceImpl(NotificationRepository notificationRepository) {
+    public NotificationServiceImpl(
+            NotificationRepository notificationRepository, UserService userService) {
         this.notificationRepository = notificationRepository;
+        this.userService = userService;
     }
 
     @Override
     public NotificationDTO createNotification(NotificationCreateDTO notificationCreateDTO) {
         Notification notification =
                 Notification.builder()
-                        .users(notificationCreateDTO.getUsers())
+                        .userToNotify(notificationCreateDTO.getUserToNotify())
                         .comment(notificationCreateDTO.getComment())
                         .discussion(notificationCreateDTO.getDiscussion())
                         .project(notificationCreateDTO.getProject())
                         .type(notificationCreateDTO.getType())
                         .user(notificationCreateDTO.getUser())
+                        .date(LocalDateTime.now())
                         .build();
         return notificationRepository.save(notification).toDTO();
+    }
+
+    @Override
+    public List<NotificationDTO> getNotificationsOfLoggedUser() {
+        User loggedUser = userService.getLoggedUser();
+
+        val notifications = notificationRepository.findAllByUserToNotify(loggedUser);
+        if (notifications.size() > 1) {
+            notifications.sort(Comparator.comparing(Notification::getDate));
+            Collections.reverse(notifications);
+        }
+        return notifications.stream().map(Notification::toDTO).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/a2/backend/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/ProjectServiceImpl.java
@@ -9,15 +9,14 @@ import com.a2.backend.repository.LanguageRepository;
 import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.repository.TagRepository;
 import com.a2.backend.service.*;
-import lombok.val;
-import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.transaction.Transactional;
+import lombok.val;
+import org.springframework.stereotype.Service;
 
 @Service
 public class ProjectServiceImpl implements ProjectService {
@@ -390,7 +389,7 @@ public class ProjectServiceImpl implements ProjectService {
                         .type(NotificationType.APPLICANT)
                         .project(project)
                         .user(loggedUser)
-                        .users(List.of(project.getOwner()))
+                        .userToNotify(project.getOwner())
                         .build();
         notificationService.createNotification(notificationCreateDTO);
 
@@ -538,7 +537,7 @@ public class ProjectServiceImpl implements ProjectService {
                         .type(NotificationType.REVIEW)
                         .project(project)
                         .user(loggedUser)
-                        .users(List.of(review.getCollaborator()))
+                        .userToNotify(review.getCollaborator())
                         .build();
         notificationService.createNotification(notificationCreateDTO);
 

--- a/src/test/java/com/a2/backend/controller/NotificationControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/NotificationControllerActiveTest.java
@@ -1,0 +1,49 @@
+package com.a2.backend.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.a2.backend.model.NotificationDTO;
+import com.a2.backend.repository.NotificationRepository;
+import com.a2.backend.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@AutoConfigureMockMvc
+public class NotificationControllerActiveTest extends AbstractControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @Autowired ObjectMapper objectMapper;
+
+    @Autowired NotificationRepository notificationRepository;
+
+    @Autowired UserService userService;
+
+    private final String baseUrl = "/notification";
+
+    @Test
+    @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
+    void Test001_NotificationControllerShouldReturnLoggedUserNotificationsAndHttpOkTest()
+            throws Exception {
+
+        String contentAsString =
+                mvc.perform(MockMvcRequestBuilders.get(baseUrl).accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        val notifications = objectMapper.readValue(contentAsString, NotificationDTO[].class);
+
+        assertNotNull(notifications);
+        assertEquals(3, notifications.length);
+    }
+}

--- a/src/test/java/com/a2/backend/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/a2/backend/repository/NotificationRepositoryTest.java
@@ -1,8 +1,14 @@
 package com.a2.backend.repository;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.a2.backend.BackendApplication;
 import com.a2.backend.constants.NotificationType;
 import com.a2.backend.entity.*;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,12 +19,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.util.Collections;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 @AutoConfigureWebClient
 @DataJpaTest
 @ExtendWith(SpringExtension.class)
@@ -27,14 +27,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 public class NotificationRepositoryTest {
 
-    @Autowired
-    UserRepository userRepository;
+    @Autowired UserRepository userRepository;
 
-    @Autowired
-    ProjectRepository projectRepository;
+    @Autowired ProjectRepository projectRepository;
 
-    @Autowired
-    NotificationRepository notificationRepository;
+    @Autowired NotificationRepository notificationRepository;
 
     User user =
             User.builder()
@@ -73,9 +70,10 @@ public class NotificationRepositoryTest {
     Notification notification =
             Notification.builder()
                     .user(anotherUser)
-                    .users(List.of(user))
+                    .userToNotify(user)
                     .project(project)
                     .type(NotificationType.REVIEW)
+                    .date(LocalDateTime.now())
                     .build();
 
     @Test
@@ -88,10 +86,10 @@ public class NotificationRepositoryTest {
 
         Notification savedNotification = notificationRepository.save(notification);
 
-        assertEquals(1, notificationRepository.findAllByUsersContaining(user).size());
+        assertEquals(1, notificationRepository.findAllByUserToNotify(user).size());
 
         assertEquals(NotificationType.REVIEW, savedNotification.getType());
-        assertEquals(user.getNickname(), savedNotification.getUsers().get(0).getNickname());
+        assertEquals(user.getNickname(), savedNotification.getUserToNotify().getNickname());
         assertEquals(anotherUser.getNickname(), savedNotification.getUser().getNickname());
         assertEquals(project.getTitle(), savedNotification.getProject().getTitle());
     }

--- a/src/test/java/com/a2/backend/service/impl/NotificationServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/NotificationServiceActiveTest.java
@@ -1,8 +1,11 @@
 package com.a2.backend.service.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.a2.backend.constants.NotificationType;
 import com.a2.backend.model.NotificationCreateDTO;
 import com.a2.backend.model.NotificationDTO;
+import com.a2.backend.repository.NotificationRepository;
 import com.a2.backend.repository.ProjectRepository;
 import com.a2.backend.service.NotificationService;
 import com.a2.backend.service.UserService;
@@ -11,20 +14,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 public class NotificationServiceActiveTest extends AbstractServiceTest {
 
-    @Autowired
-    NotificationService notificationService;
+    @Autowired NotificationService notificationService;
 
-    @Autowired
-    UserService userService;
+    @Autowired UserService userService;
 
-    @Autowired
-    ProjectRepository projectRepository;
+    @Autowired ProjectRepository projectRepository;
+
+    @Autowired NotificationRepository notificationRepository;
 
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
@@ -33,7 +31,7 @@ public class NotificationServiceActiveTest extends AbstractServiceTest {
 
         NotificationCreateDTO notificationCreateDTO =
                 NotificationCreateDTO.builder()
-                        .users(List.of(userService.getLoggedUser()))
+                        .userToNotify(userService.getLoggedUser())
                         .type(NotificationType.REVIEW)
                         .project(project)
                         .user(project.getOwner())
@@ -62,7 +60,7 @@ public class NotificationServiceActiveTest extends AbstractServiceTest {
     void Test002_NotificationServiceWhenCreatingNotificationWithAllowedNullFieldsThenItIsCreated() {
         NotificationCreateDTO notificationCreateDTO =
                 NotificationCreateDTO.builder()
-                        .users(List.of(userService.getLoggedUser()))
+                        .userToNotify(userService.getLoggedUser())
                         .type(NotificationType.REVIEW)
                         .build();
 
@@ -76,5 +74,14 @@ public class NotificationServiceActiveTest extends AbstractServiceTest {
         assertNull(notification.getComment());
         assertNull(notification.getDiscussion());
         assertFalse(notification.isSeen());
+    }
+
+    @Test
+    @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
+    void Test003_NotificationServiceShouldReturnAllLoggedUsersNotificationsOrderedByDate() {
+        val notifications = notificationService.getNotificationsOfLoggedUser();
+        assertEquals(3, notifications.size());
+        assertTrue(notifications.get(0).getDate().isAfter(notifications.get(1).getDate()));
+        assertTrue(notifications.get(1).getDate().isAfter(notifications.get(2).getDate()));
     }
 }


### PR DESCRIPTION
Como usuario autenticado quiero poder ver todas mis notificaciones tal que pueda tener una visión más amplia que las de la bandeja de entrada
UATs:

-La página de notificaciones debe mostrar el listado de todas las notificaciones leídas y no leídas
-Estas deben estar ordenadas por fecha de creación

Ahora una notificación tiene un único usuario al que notifica en vez de una lista 