### PR TITLE
Added feature return first five notifications

### DIFF
--- a/src/main/java/com/a2/backend/controller/NotificationController.java
+++ b/src/main/java/com/a2/backend/controller/NotificationController.java
@@ -33,4 +33,11 @@ public class NotificationController {
         val notification = notificationService.markNotificationAsSeen(id);
         return ResponseEntity.status(HttpStatus.OK).body(notification);
     }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @GetMapping("/first-five")
+    public ResponseEntity<?> getFirstFiveNotificationsOfLoggedUser() {
+        val userNotifications = notificationService.getFirstFiveNotificationsOfLoggedUser();
+        return ResponseEntity.status(HttpStatus.OK).body(userNotifications);
+    }
 }

--- a/src/main/java/com/a2/backend/entity/Notification.java
+++ b/src/main/java/com/a2/backend/entity/Notification.java
@@ -3,7 +3,6 @@ package com.a2.backend.entity;
 import com.a2.backend.constants.NotificationType;
 import com.a2.backend.model.NotificationDTO;
 import lombok.*;
-
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;

--- a/src/main/java/com/a2/backend/service/NotificationService.java
+++ b/src/main/java/com/a2/backend/service/NotificationService.java
@@ -2,7 +2,6 @@ package com.a2.backend.service;
 
 import com.a2.backend.model.NotificationCreateDTO;
 import com.a2.backend.model.NotificationDTO;
-
 import java.util.List;
 import java.util.UUID;
 
@@ -12,4 +11,6 @@ public interface NotificationService {
     List<NotificationDTO> getNotificationsOfLoggedUser();
 
     NotificationDTO markNotificationAsSeen(UUID id);
+
+    List<NotificationDTO> getFirstFiveNotificationsOfLoggedUser();
 }

--- a/src/main/java/com/a2/backend/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/NotificationServiceImpl.java
@@ -75,4 +75,9 @@ public class NotificationServiceImpl implements NotificationService {
         notification.setSeen(true);
         return notificationRepository.save(notification).toDTO();
     }
+
+    @Override
+    public List<NotificationDTO> getFirstFiveNotificationsOfLoggedUser() {
+        return getNotificationsOfLoggedUser().subList(0, 5);
+    }
 }

--- a/src/main/java/com/a2/backend/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/a2/backend/service/impl/NotificationServiceImpl.java
@@ -78,6 +78,9 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     public List<NotificationDTO> getFirstFiveNotificationsOfLoggedUser() {
-        return getNotificationsOfLoggedUser().subList(0, 5);
+        if (getNotificationsOfLoggedUser().size() >= 5) {
+            return getNotificationsOfLoggedUser().subList(0, 5);
+        }
+        return getNotificationsOfLoggedUser();
     }
 }

--- a/src/test/java/com/a2/backend/controller/NotificationControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/NotificationControllerActiveTest.java
@@ -72,4 +72,24 @@ public class NotificationControllerActiveTest extends AbstractControllerTest {
 
         assertTrue(notification.isSeen());
     }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test002_NotificationControllerShouldReturnLoggedUserFirstFiveNotificationsAndHttpOkTest()
+            throws Exception {
+
+        String contentAsString =
+                mvc.perform(
+                                MockMvcRequestBuilders.get(baseUrl + "/first-five")
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        val notifications = objectMapper.readValue(contentAsString, NotificationDTO[].class);
+
+        assertNotNull(notifications);
+        assertEquals(5, notifications.length);
+    }
 }

--- a/src/test/java/com/a2/backend/controller/NotificationControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/NotificationControllerActiveTest.java
@@ -92,4 +92,24 @@ public class NotificationControllerActiveTest extends AbstractControllerTest {
         assertNotNull(notifications);
         assertEquals(5, notifications.length);
     }
+
+    @Test
+    @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
+    void Test003_NotificationControllerShouldReturnLoggedUserAllNotificationsAndHttpOkTest()
+            throws Exception {
+
+        String contentAsString =
+                mvc.perform(
+                                MockMvcRequestBuilders.get(baseUrl + "/first-five")
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        val notifications = objectMapper.readValue(contentAsString, NotificationDTO[].class);
+
+        assertNotNull(notifications);
+        assertEquals(3, notifications.length);
+    }
 }

--- a/src/test/java/com/a2/backend/controller/NotificationControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/NotificationControllerActiveTest.java
@@ -75,7 +75,7 @@ public class NotificationControllerActiveTest extends AbstractControllerTest {
 
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
-    void Test002_NotificationControllerShouldReturnLoggedUserFirstFiveNotificationsAndHttpOkTest()
+    void Test003_NotificationControllerShouldReturnLoggedUserFirstFiveNotificationsAndHttpOkTest()
             throws Exception {
 
         String contentAsString =
@@ -95,7 +95,7 @@ public class NotificationControllerActiveTest extends AbstractControllerTest {
 
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test003_NotificationControllerShouldReturnLoggedUserAllNotificationsAndHttpOkTest()
+    void Test004_NotificationControllerShouldReturnLoggedUserAllNotificationsAndHttpOkTest()
             throws Exception {
 
         String contentAsString =

--- a/src/test/java/com/a2/backend/service/impl/NotificationServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/NotificationServiceActiveTest.java
@@ -135,4 +135,13 @@ public class NotificationServiceActiveTest extends AbstractServiceTest {
         assertTrue(notifications.get(0).getDate().isAfter(notifications.get(1).getDate()));
         assertTrue(notifications.get(1).getDate().isAfter(notifications.get(2).getDate()));
     }
+
+    @Test
+    @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
+    void Test005_NotificationServiceShouldReturnAllLoggedUsersNotificationsOrderedByDate() {
+        val notifications = notificationService.getFirstFiveNotificationsOfLoggedUser();
+        assertEquals(3, notifications.size());
+        assertTrue(notifications.get(0).getDate().isAfter(notifications.get(1).getDate()));
+        assertTrue(notifications.get(1).getDate().isAfter(notifications.get(2).getDate()));
+    }
 }

--- a/src/test/java/com/a2/backend/service/impl/NotificationServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/NotificationServiceActiveTest.java
@@ -126,4 +126,13 @@ public class NotificationServiceActiveTest extends AbstractServiceTest {
                 InvalidUserException.class,
                 () -> notificationService.markNotificationAsSeen(notifications.get(0).getId()));
     }
+
+    @Test
+    @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
+    void Test004_NotificationServiceShouldReturnFirstFiveLoggedUsersNotificationsOrderedByDate() {
+        val notifications = notificationService.getFirstFiveNotificationsOfLoggedUser();
+        assertEquals(5, notifications.size());
+        assertTrue(notifications.get(0).getDate().isAfter(notifications.get(1).getDate()));
+        assertTrue(notifications.get(1).getDate().isAfter(notifications.get(2).getDate()));
+    }
 }

--- a/src/test/java/com/a2/backend/service/impl/NotificationServiceActiveTest.java
+++ b/src/test/java/com/a2/backend/service/impl/NotificationServiceActiveTest.java
@@ -129,7 +129,7 @@ public class NotificationServiceActiveTest extends AbstractServiceTest {
 
     @Test
     @WithMockUser("rodrigo.pazos@ing.austral.edu.ar")
-    void Test004_NotificationServiceShouldReturnFirstFiveLoggedUsersNotificationsOrderedByDate() {
+    void Test007_NotificationServiceShouldReturnFirstFiveLoggedUsersNotificationsOrderedByDate() {
         val notifications = notificationService.getFirstFiveNotificationsOfLoggedUser();
         assertEquals(5, notifications.size());
         assertTrue(notifications.get(0).getDate().isAfter(notifications.get(1).getDate()));
@@ -138,7 +138,7 @@ public class NotificationServiceActiveTest extends AbstractServiceTest {
 
     @Test
     @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
-    void Test005_NotificationServiceShouldReturnAllLoggedUsersNotificationsOrderedByDate() {
+    void Test008_NotificationServiceShouldReturnAllLoggedUsersNotificationsOrderedByDate() {
         val notifications = notificationService.getFirstFiveNotificationsOfLoggedUser();
         assertEquals(3, notifications.size());
         assertTrue(notifications.get(0).getDate().isAfter(notifications.get(1).getDate()));


### PR DESCRIPTION
Como usuario autenticado quiero poder ver mis primeras 5 notificaciones 
UATs:

La página de notificaciones debe mostrar el listado de las primeras 5 notificaciones leídas y no leídas
Estas deben estar ordenadas por fecha de creación