### PR TITLE
Added feature marcar notificación como leída

### DIFF
--- a/src/main/java/com/a2/backend/controller/NotificationController.java
+++ b/src/main/java/com/a2/backend/controller/NotificationController.java
@@ -8,6 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequestMapping("/notification")
 public class NotificationController {
@@ -23,5 +25,12 @@ public class NotificationController {
     public ResponseEntity<?> getNotificationsOfLoggedUser() {
         val userNotifications = notificationService.getNotificationsOfLoggedUser();
         return ResponseEntity.status(HttpStatus.OK).body(userNotifications);
+    }
+
+    @Secured({SecurityConstants.USER_ROLE})
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateNotification(@PathVariable("id") UUID id) {
+        val notification = notificationService.markNotificationAsSeen(id);
+        return ResponseEntity.status(HttpStatus.OK).body(notification);
     }
 }

--- a/src/main/java/com/a2/backend/entity/Notification.java
+++ b/src/main/java/com/a2/backend/entity/Notification.java
@@ -2,12 +2,12 @@ package com.a2.backend.entity;
 
 import com.a2.backend.constants.NotificationType;
 import com.a2.backend.model.NotificationDTO;
-import java.time.LocalDateTime;
-import java.util.UUID;
-import javax.persistence.*;
-import javax.validation.constraints.NotNull;
 import lombok.*;
 
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Getter

--- a/src/main/java/com/a2/backend/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/a2/backend/exception/NotificationNotFoundException.java
@@ -1,0 +1,7 @@
+package com.a2.backend.exception;
+
+public class NotificationNotFoundException extends RuntimeException {
+    public NotificationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
+++ b/src/main/java/com/a2/backend/exceptionhandler/DefaultExceptionHandler.java
@@ -1,8 +1,6 @@
 package com.a2.backend.exceptionhandler;
 
 import com.a2.backend.exception.*;
-import java.util.Arrays;
-import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -12,6 +10,9 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.Arrays;
+import java.util.Objects;
 
 @ControllerAdvice
 public class DefaultExceptionHandler {
@@ -142,6 +143,13 @@ public class DefaultExceptionHandler {
 
     @ExceptionHandler(CommentNotFoundException.class)
     protected ResponseEntity<?> handleCommentNotFound(CommentNotFoundException exception) {
+        logger.info(exception.getMessage());
+        return new ResponseEntity(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(NotificationNotFoundException.class)
+    protected ResponseEntity<?> handleNotificationNotFound(
+            NotificationNotFoundException exception) {
         logger.info(exception.getMessage());
         return new ResponseEntity(exception.getMessage(), HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/a2/backend/service/NotificationService.java
+++ b/src/main/java/com/a2/backend/service/NotificationService.java
@@ -2,10 +2,14 @@ package com.a2.backend.service;
 
 import com.a2.backend.model.NotificationCreateDTO;
 import com.a2.backend.model.NotificationDTO;
+
 import java.util.List;
+import java.util.UUID;
 
 public interface NotificationService {
     NotificationDTO createNotification(NotificationCreateDTO notificationCreateDTO);
 
     List<NotificationDTO> getNotificationsOfLoggedUser();
+
+    NotificationDTO markNotificationAsSeen(UUID id);
 }

--- a/src/test/java/com/a2/backend/controller/DiscussionControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/DiscussionControllerActiveTest.java
@@ -1,18 +1,11 @@
 package com.a2.backend.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.a2.backend.entity.Comment;
 import com.a2.backend.entity.Discussion;
 import com.a2.backend.model.*;
 import com.a2.backend.repository.DiscussionRepository;
 import com.a2.backend.repository.ProjectRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
 import lombok.val;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,14 +15,25 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @AutoConfigureMockMvc
 class DiscussionControllerActiveTest extends AbstractControllerTest {
 
-    @Autowired MockMvc mvc;
+    @Autowired
+    MockMvc mvc;
 
-    @Autowired ObjectMapper objectMapper;
+    @Autowired
+    ObjectMapper objectMapper;
 
-    @Autowired ProjectRepository projectRepository;
+    @Autowired
+    ProjectRepository projectRepository;
 
     @Autowired DiscussionRepository discussionRepository;
 
@@ -680,6 +684,4 @@ class DiscussionControllerActiveTest extends AbstractControllerTest {
 
         assertEquals(1, projectRepository.findByTitle("Kubernetes").get().getDiscussions().size());
     }
-
-
 }

--- a/src/test/java/com/a2/backend/controller/NotificationControllerActiveTest.java
+++ b/src/test/java/com/a2/backend/controller/NotificationControllerActiveTest.java
@@ -1,8 +1,5 @@
 package com.a2.backend.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.a2.backend.model.NotificationDTO;
 import com.a2.backend.repository.NotificationRepository;
 import com.a2.backend.service.UserService;
@@ -15,6 +12,11 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
 public class NotificationControllerActiveTest extends AbstractControllerTest {
@@ -45,5 +47,29 @@ public class NotificationControllerActiveTest extends AbstractControllerTest {
 
         assertNotNull(notifications);
         assertEquals(3, notifications.length);
+    }
+
+    @Test
+    @WithMockUser(username = "agustin.ayerza@ing.austral.edu.ar")
+    void Test002_NotificationControllerWhenMarkingNotificationAsReadThenHttpOkIsReturned()
+            throws Exception {
+        UUID id =
+                notificationRepository
+                        .findAllByUserToNotify(userService.getLoggedUser())
+                        .get(0)
+                        .getId();
+
+        String contentAsString =
+                mvc.perform(
+                                MockMvcRequestBuilders.put(baseUrl + "/" + id)
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        val notification = objectMapper.readValue(contentAsString, NotificationDTO.class);
+
+        assertTrue(notification.isSeen());
     }
 }


### PR DESCRIPTION
Como usuario autenticado quiero poder marcar una notificación como leída tal que pueda organizar mi lista de notificaciones.
UATs:
Desde la página de notificaciones se debe poder marcar una notificación como leída solo si esta no fue marcada como leída anteriormente.
De marcar como leída correctamente la notificación pasa al listado de notificaciones leídas y se muestra un mensaje confirmando que se marcó la notificación como leída
De haber un error al marcar como leída se muestra un mensaje de error
